### PR TITLE
SCRIPTS: Add wsmux and bmux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
-[submodule "rawgps-tools"]
-	path = rawgps-tools
-	url = https://github.com/uf-mil/rawgps-tools
+[submodule "odometry_tools"]
+	path = odometry_tools
+	url = https://github.com/uf-mil/odometry_tools.git
 [submodule "txros"]
 	path = txros
-	url = https://github.com/txros/txros
+	url = https://github.com/txros/txros.git
 [submodule "ros_alarms"]
 	path = ros_alarms
-	url = https://github.com/uf-mil/ros_alarms
+	url = https://github.com/uf-mil/ros_alarms.git

--- a/readme.md
+++ b/readme.md
@@ -3,4 +3,4 @@ This repository is the foundation of the software used on MIL's projects. It con
 
 # Getting Involved
 
-Information about getting involved in MIL is available on the [software-common wiki](https://github.com/uf-mil/software-common/wiki). The home page will introduce you to the various projects that are under development in the lab and provide a link to the getting started guide.
+Information about getting involved in MIL is available on the [mil_common wiki](https://github.com/uf-mil/mil_common/wiki). The home page will introduce you to the various projects that are under development in the lab and provide a link to the getting started guide.

--- a/scripts/bag_backup.sh
+++ b/scripts/bag_backup.sh
@@ -24,17 +24,10 @@
 # mounted.
 
 
-#======================#
-# Script Configuration #
-#======================#
-
 # The directories to sync are set in the command to run the script
 LOCAL_BAGS_DIR=$1
 REMOTE_BAGS_DIR=$2
 
-#================#
-# Backup Command #
-#================#
 
 if [ -d $REMOTE_BAGS_DIR ]; then
 	echo "Synchronizing bags to the MIL fileserver share mounted at $REMOTE_BAGS_DIR"

--- a/scripts/bag_backup.sh
+++ b/scripts/bag_backup.sh
@@ -9,7 +9,7 @@
 # # Backup the bags to the MIL fileserver if it is available
 # USER={user that owns the bags directory}
 # CATKIN_DIR={The directory of the user's catkin workspace}
-# BAG_BACKUP_SCRIPT=$CATKIN_DIR/src/software-common/scripts/bag_backup.sh
+# BAG_BACKUP_SCRIPT=$CATKIN_DIR/src/mil_common/scripts/bag_backup.sh
 # LOCAL_BAGS_DIR={bags directory on the internal drive}
 # REMOTE_BAGS_DIR={bags directory on the mounted MIL fileserver share}
 # sudo -u $USER -i screen -dmS bag-backup bash -i -c \

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -14,15 +14,15 @@ source $CATKIN_DIR/src/software-common/scripts/ros_connect.sh
 alias swc="cd $CATKIN_DIR/src/software-common"
 
 # Bash sourcing
-alias srcbrc='source ~/.bashrc'
+alias srcbrc="source ~/.bashrc"
 
 # Catkin workspace management
-alias cm='catkin_make -C $CATKIN_DIR'
+alias cm="catkin_make -C $CATKIN_DIR -j8"
 
 # Alarms
-alias araise='rosrun ros_alarms raise'
-alias aclear='rosrun ros_alarms clear'
-alias areport='rosrun ros_alarms report'
+alias araise="rosrun ros_alarms raise"
+alias aclear="rosrun ros_alarms clear"
+alias areport="rosrun ros_alarms report"
 
 # Simulation
 alias killgazebo="killall -9 gazebo && killall -9 gzserver && killall -9 gzclient"

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -6,11 +6,13 @@
 # aliased to make them faster or easier to execute. Becoming familiar with
 # these will likely increase productivity, so it is recommended to do so.
 
+
 # Source external alias modules
 source $CATKIN_DIR/src/mil_common/scripts/two_line_bash.sh
 source $CATKIN_DIR/src/mil_common/scripts/ros_connect.sh
 source $CATKIN_DIR/src/mil_common/scripts/wsmux.sh
 source $CATKIN_DIR/src/mil_common/scripts/bmux.sh
+
 
 # Directory navigation
 alias swc="cd $CATKIN_DIR/src/mil_common"

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -14,6 +14,14 @@ source $CATKIN_DIR/src/mil_common/scripts/wsmux.sh
 source $CATKIN_DIR/src/mil_common/scripts/bmux.sh
 
 
+# Debugging for ROS networking
+ros_env() {
+	echo "ROS_IP=$ROS_IP"
+	echo "ROS_HOSTNAME=$ROS_HOSTNAME"
+	echo "ROS_MASTER_URI=$ROS_MASTER_URI"
+}
+
+
 # Directory navigation
 alias mc="cd $CATKIN_DIR/src/mil_common"
 

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -10,6 +10,7 @@
 source $CATKIN_DIR/src/mil_common/scripts/two_line_bash.sh
 source $CATKIN_DIR/src/mil_common/scripts/ros_connect.sh
 source $CATKIN_DIR/src/mil_common/scripts/wsmux.sh
+source $CATKIN_DIR/src/mil_common/scripts/bmux.sh
 
 # Directory navigation
 alias swc="cd $CATKIN_DIR/src/mil_common"

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -9,6 +9,7 @@
 # Source external alias modules
 source $CATKIN_DIR/src/mil_common/scripts/two_line_bash.sh
 source $CATKIN_DIR/src/mil_common/scripts/ros_connect.sh
+source $CATKIN_DIR/src/mil_common/scripts/wsmux.sh
 
 # Directory navigation
 alias swc="cd $CATKIN_DIR/src/mil_common"

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -7,11 +7,11 @@
 # these will likely increase productivity, so it is recommended to do so.
 
 # Source external alias modules
-source $CATKIN_DIR/src/software-common/scripts/two_line_bash.sh
-source $CATKIN_DIR/src/software-common/scripts/ros_connect.sh
+source $CATKIN_DIR/src/mil_common/scripts/two_line_bash.sh
+source $CATKIN_DIR/src/mil_common/scripts/ros_connect.sh
 
 # Directory navigation
-alias swc="cd $CATKIN_DIR/src/software-common"
+alias swc="cd $CATKIN_DIR/src/mil_common"
 
 # Bash sourcing
 alias srcbrc="source ~/.bashrc"

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -15,7 +15,7 @@ source $CATKIN_DIR/src/mil_common/scripts/bmux.sh
 
 
 # Directory navigation
-alias swc="cd $CATKIN_DIR/src/mil_common"
+alias mc="cd $CATKIN_DIR/src/mil_common"
 
 # Bash sourcing
 alias srcbrc="source ~/.bashrc"

--- a/scripts/bmux.sh
+++ b/scripts/bmux.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+# The bmux command is used to manage sourcing the bagging aliases for different
+# MIL vehicles. This prevents setting potentially hundreds of aliases in each
+# new shell. It also allows us to prefix the aliases with bag_* as opposed to
+# bag_{vehicle}_*. Each project with bagging aliases should contain a
+# scripts/bagging_aliases.sh file.
+
+
+BAGGING_ALIAS_FILE="scripts/bagging_aliases.sh"
+
+
+_bagging_aliases_complete() {
+	local FILE
+
+	# Check for bagging aliase files in the catkin workspace repositories
+	for FILE in $CATKIN_DIR/src/*; do
+
+		# Skip any repository that does not contain a bagging aliases file
+		[[ -f $FILE/$BAGGING_ALIAS_FILE ]] || continue
+
+		# Append just the name of the repository to the autocomplete list
+		COMPREPLY+=( `echo "$FILE" | rev | cut -d "/" -f1 | rev` )
+	done
+}
+
+bmux() {
+	local SELECTION
+	local BAGGING_ALIASES="`alias | grep 'bag' | cut -d '=' -f1 | cut -d ' ' -f2`"
+
+	# Get the list of catkin workspaces containing bagging aliases files
+	_bagging_aliases_complete
+
+	# Handles command line arguments
+	while [ "$#" -gt 0 ]; do
+		case $1 in
+			-h|--help)
+				echo "Usage: bmux [OPTION] [REPOSITORY]..."
+				echo "Manager for sourcing bagging aliases for different MIL vehicles."
+				echo ""
+				echo "Option		GNU long option		Meaning"
+				echo "-h		--help			Display the help menu"
+				echo "-l		--list			List projects with bagging aliases"
+				echo "-s		--show			Show current bagging aliases"
+				echo "-c		--clear			Clear current bagging aliases"
+				shift 1
+				;;
+			-l|--list)
+				echo "$COMPREPLY" | sed ':a;N;$!ba;s/\n/  /g'
+				shift 1
+				;;
+			-s|--show)
+				if [ ! -z "$BAGGING_ALIASES" ]; then
+					echo "$BAGGING_ALIASES" | sed ':a;N;$!ba;s/\n/  /g'
+				fi
+				shift 1
+				;;
+			-c|--clear)
+				if [ ! -z "$BAGGING_ALIASES" ]; then
+					for ALIAS in $BAGGING_ALIASES; do
+						unalias "$ALIAS"
+					done
+				fi
+				shift 1
+				;;
+			*)
+				if [ ! -z "`echo $COMPREPLY | grep $1`" ]; then
+					SELECTION="$1"
+				else
+					echo "Option $1 is not implemented."
+					echo "Try 'bmux --help' for more information."
+				fi
+				shift 1
+				;;
+		esac
+	done
+
+	if [ ! -z "$SELECTION" ]; then
+		if [ -f $CATKIN_DIR/src/$SELECTION/$BAGGING_ALIAS_FILE ]; then
+			source $CATKIN_DIR/src/$SELECTION/$BAGGING_ALIAS_FILE
+		fi
+	fi
+
+	unset COMPREPLY
+}
+
+
+# Registers the autocompletion function to be invoked for bmux
+complete -F _bagging_aliases_complete bmux

--- a/scripts/bmux.sh
+++ b/scripts/bmux.sh
@@ -1,23 +1,25 @@
 #!/bin/bash
 
-# The bmux command is used to manage sourcing the bagging aliases for different
-# MIL vehicles. This prevents setting potentially hundreds of aliases in each
-# new shell. It also allows us to prefix the aliases with bag_* as opposed to
-# bag_{vehicle}_*. Each project with bagging aliases should contain a
-# scripts/bagging_aliases.sh file.
+# The bmux command is used to manage sourcing the bagging variables for
+# different MIL vehicles. This prevents setting potentially hundreds of
+# variables in each new shell. It also allows us to prefix the variables with
+# bag_* as opposed to bag_{vehicle}_*. Each project with bagging variables
+# should contain a scripts/bagging_variables.sh file. A bmux command to source
+# the correct set of variables for a vehicle should be added to the bash runcom
+# file of that vehicle's main user
 
 
-BAGGING_ALIAS_FILE="scripts/bagging_aliases.sh"
+BAGGING_VARIABLES_FILE="scripts/bagging_variables.sh"
 
 
-_bagging_aliases_complete() {
+_bagging_variables_file_complete() {
 	local FILE
 
-	# Check for bagging aliase files in the catkin workspace repositories
-	for FILE in $CATKIN_DIR/src/*; do
+	# Check for bagging variables files in the catkin workspace repositories
+	for FILE in $CATKIN_DIR/src/"$2"*; do
 
-		# Skip any repository that does not contain a bagging aliases file
-		[[ -f $FILE/$BAGGING_ALIAS_FILE ]] || continue
+		# Skip any repository that does not contain a bagging variables file
+		[[ -f $FILE/$BAGGING_VARIABLES_FILE ]] || continue
 
 		# Append just the name of the repository to the autocomplete list
 		COMPREPLY+=( `echo "$FILE" | rev | cut -d "/" -f1 | rev` )
@@ -26,59 +28,76 @@ _bagging_aliases_complete() {
 
 bmux() {
 	local SELECTION
-	local BAGGING_ALIASES="`alias | grep 'bag' | cut -d '=' -f1 | cut -d ' ' -f2`"
+	local BAGGING_VARIABLES="`env | grep 'bag_' | cut -d '=' -f1 | cut -d ' ' -f2`"
 
-	# Get the list of catkin workspaces containing bagging aliases files
-	_bagging_aliases_complete
+	# Get the list of catkin workspaces containing bagging variables files
+	_bagging_variables_file_complete
 
 	# Handles command line arguments
 	while [ "$#" -gt 0 ]; do
 		case $1 in
+			-c|--clear)
+				if [ ! -z "$BAGGING_VARIABLES" ]; then
+					for VARIABLE in $BAGGING_VARIABLES; do
+						unset "$VARIABLE"
+					done
+				fi
+
+				# Special variables used in the bag command
+				unset BAG_ALWAYS
+				unset BAG_HOME
+				SELECTION=false
+				shift 1
+				;;
 			-h|--help)
-				echo "Usage: bmux [OPTION] [REPOSITORY]..."
-				echo "Manager for sourcing bagging aliases for different MIL vehicles."
+				echo "Usage: bmux [OPTION]... [REPOSITORY]"
+				echo "Manager for sourcing bagging variables for different MIL vehicles."
 				echo ""
 				echo "Option		GNU long option		Meaning"
+				echo "-c		--clear			Clear current bagging variables"
 				echo "-h		--help			Display the help menu"
-				echo "-l		--list			List projects with bagging aliases"
-				echo "-s		--show			Show current bagging aliases"
-				echo "-c		--clear			Clear current bagging aliases"
+				echo "-l		--list			List projects with bagging variables"
+				echo "-s		--show			Show current bagging variables"
+				SELECTION=false
 				shift 1
 				;;
 			-l|--list)
-				echo "$COMPREPLY" | sed ':a;N;$!ba;s/\n/  /g'
+				if [ ! -z "$COMPREPLY" ]; then
+					echo "${COMPREPLY[@]}" | sed 's/ /  /g'
+				fi
+				SELECTION=false
 				shift 1
 				;;
 			-s|--show)
-				if [ ! -z "$BAGGING_ALIASES" ]; then
-					echo "$BAGGING_ALIASES" | sed ':a;N;$!ba;s/\n/  /g'
+				if [ ! -z "$BAGGING_VARIABLES" ]; then
+					echo "$BAGGING_VARIABLES" | sed ':a;N;$!ba;s/\n/  /g'
 				fi
+				SELECTION=false
 				shift 1
 				;;
-			-c|--clear)
-				if [ ! -z "$BAGGING_ALIASES" ]; then
-					for ALIAS in $BAGGING_ALIASES; do
-						unalias "$ALIAS"
-					done
-				fi
+			-*)
+				echo "Option $1 is not implemented."
+				echo "Try 'bmux --help' for more information."
+				SELECTION=false
 				shift 1
 				;;
 			*)
-				if [ ! -z "`echo $COMPREPLY | grep $1`" ]; then
-					SELECTION="$1"
-				else
-					echo "Option $1 is not implemented."
-					echo "Try 'bmux --help' for more information."
+				if [ "$SELECTION" != "false" ]; then
+					if [ -f $CATKIN_DIR/src/"$1"/$BAGGING_VARIABLES_FILE ]; then
+						SELECTION="$1"
+					else
+						echo "$CATKIN_DIR/src/$1 has no scripts/bagging_variables.sh file."
+						echo "Try 'bmux --help' for more information."
+						SELECTION=false
+					fi
 				fi
 				shift 1
 				;;
 		esac
 	done
 
-	if [ ! -z "$SELECTION" ]; then
-		if [ -f $CATKIN_DIR/src/$SELECTION/$BAGGING_ALIAS_FILE ]; then
-			source $CATKIN_DIR/src/$SELECTION/$BAGGING_ALIAS_FILE
-		fi
+	if [ ! -z "$SELECTION" ] && [ "$SELECTION" != "false" ]; then
+			source $CATKIN_DIR/src/$SELECTION/$BAGGING_VARIABLES_FILE
 	fi
 
 	unset COMPREPLY
@@ -86,4 +105,4 @@ bmux() {
 
 
 # Registers the autocompletion function to be invoked for bmux
-complete -F _bagging_aliases_complete bmux
+complete -F _bagging_variables_file_complete bmux

--- a/scripts/ros_connect.sh
+++ b/scripts/ros_connect.sh
@@ -196,12 +196,6 @@ ros_disconnect() {
 }
 
 
-# Prints debugging output for the master roscore that is currently selected
-alias ros_env='echo "ROS_IP=$ROS_IP
-ROS_HOSTNAME=$ROS_HOSTNAME
-ROS_MASTER_URI=$ROS_MASTER_URI"'
-
-
 # Generates the persistence file if it does not exist
 if [ ! -f $PERSISTENCE_FILE ]; then
 	echo $DEFAULT_HOST > $PERSISTENCE_FILE

--- a/scripts/ros_connect.sh
+++ b/scripts/ros_connect.sh
@@ -102,29 +102,15 @@ ros_connect() {
 	while [ "$#" -gt 0 ]; do
 		case $1 in
 			-h|--help)
-				echo "Usage: ros_connect [OPTION] [HOSTNAME]..."
+				echo "Usage: ros_connect [OPTION]..."
 				echo "Manager for connections to remote roscores."
 				echo ""
 				echo "Option		GNU long option		Meaning"
 				echo "-h		--help			Display the help menu"
-				echo "-p		--persistence		Toggle persistence across shells"
-				echo "-o		--one-time		Only set the roscore for this shell"
 				echo "-n [HOSTNAME]	--hostname		Manually pass in a hostname"
+				echo "-o		--one-time		Only set the roscore for this shell"
+				echo "-p		--persistence		Toggle persistence across shells"
 				HOST_DISCOVERY=false
-				PERSIST=false
-				shift 1
-				;;
-			-p|--persistence)
-				if [ -z `cat $PERSISTENCE_FILE | grep "disabled"` ]; then
-					echo "disabled" > $PERSISTENCE_FILE
-				else
-					echo $DEFAULT_HOST > $PERSISTENCE_FILE
-				fi
-				HOST_DISCOVERY=false
-				PERSIST=false
-				shift 1
-				;;
-			-o|--one-time)
 				PERSIST=false
 				shift 1
 				;;
@@ -138,6 +124,20 @@ ros_connect() {
 				set_ros_master $HOST
 				HOST_DISCOVERY=false
 				shift 2
+				;;
+			-o|--one-time)
+				PERSIST=false
+				shift 1
+				;;
+			-p|--persistence)
+				if [ -z `cat $PERSISTENCE_FILE | grep "disabled"` ]; then
+					echo "disabled" > $PERSISTENCE_FILE
+				else
+					echo $DEFAULT_HOST > $PERSISTENCE_FILE
+				fi
+				HOST_DISCOVERY=false
+				PERSIST=false
+				shift 1
 				;;
 			*)
 				echo "Option $1 is not implemented."

--- a/scripts/ros_connect.sh
+++ b/scripts/ros_connect.sh
@@ -11,6 +11,7 @@
 
 
 # These parameters define the network to search on
+DEFAULT_HOST="localhost"
 SEARCH_DOMAIN="ad.mil.ufl.edu"
 SUBNET="192.168.37.0/24"
 
@@ -27,11 +28,7 @@ COMMNAMES=(	"SubjuGator"
 )
 
 # The hostname persistence file
-DEFAULT_HOST="localhost"
 PERSISTENCE_FILE=~/.ros_connect_persistence
-if [ ! -f $PERSISTENCE_FILE ]; then
-	echo $DEFAULT_HOST > $PERSISTENCE_FILE
-fi
 
 
 check_host() {
@@ -198,10 +195,17 @@ ros_disconnect() {
 	ros_connect -n $DEFAULT_HOST
 }
 
+
 # Prints debugging output for the master roscore that is currently selected
 alias ros_env='echo "ROS_IP=$ROS_IP
 ROS_HOSTNAME=$ROS_HOSTNAME
 ROS_MASTER_URI=$ROS_MASTER_URI"'
+
+
+# Generates the persistence file if it does not exist
+if [ ! -f $PERSISTENCE_FILE ]; then
+	echo $DEFAULT_HOST > $PERSISTENCE_FILE
+fi
 
 # A simple implementation of hostname selection persistence
 if [ -z `cat $PERSISTENCE_FILE | grep "disabled"` ] && [ ! -z "`cat $PERSISTENCE_FILE`" ]; then

--- a/scripts/two_line_bash.sh
+++ b/scripts/two_line_bash.sh
@@ -7,6 +7,7 @@
 # the user's home directory. This can be accomplished with the following
 # command: touch ~/.disable_tlb
 
+
 function parse_git_branch {
 	PS_BRANCH=''
 	PS_FILL=${PS_LINE:0:$COLUMNS}
@@ -20,6 +21,7 @@ function parse_git_branch {
 	ref=$(git symbolic-ref HEAD 2> /dev/null) || return
 	PS_BRANCH="(git ${ref#refs/heads/}) "
 }
+
 
 if [ ! -f ~/.disable_tlb ]; then
 	RESET="\[\033[0m\]"

--- a/scripts/two_line_bash.sh
+++ b/scripts/two_line_bash.sh
@@ -8,11 +8,18 @@
 # command: touch ~/.disable_tlb
 
 
+function parse_catkin_workspace {
+	PS_WORKSPACE=""
+	local WORKSPACE_DIR="`echo $ROS_PACKAGE_PATH | cut -d ':' -f1 | sed 's@/src@@'`"
+	if [ -f $WORKSPACE_DIR/.catkin_workspace ]; then
+		PS_WORKSPACE="(catkin `echo $WORKSPACE_DIR | rev | cut -d "/" -f1 | rev`) "
+	fi
+}
+
 function parse_git_branch {
-	PS_BRANCH=''
-	PS_FILL=${PS_LINE:0:$COLUMNS}
+	PS_BRANCH=""
 	if [ -d .svn ]; then
-		PS_BRANCH="(svn r$(svn info|awk '/Revision/{print $2}'))"
+		PS_BRANCH="(svn r$(svn info|awk '/Revision/{print $2}')) "
 		return
 	elif [ -f _FOSSIL_ -o -f .fslckout ]; then
 		PS_BRANCH="(fossil $(fossil status|awk '/tags/{print $2}')) "
@@ -20,6 +27,11 @@ function parse_git_branch {
 	fi
 	ref=$(git symbolic-ref HEAD 2> /dev/null) || return
 	PS_BRANCH="(git ${ref#refs/heads/}) "
+}
+
+function parse_tlb_info {
+	parse_catkin_workspace
+	parse_git_branch
 }
 
 
@@ -30,10 +42,12 @@ if [ ! -f ~/.disable_tlb ]; then
 	BLUE="\[\033[01;34m\]"
 	YELLOW="\[\033[0;33m\]"
 
-	PS_LINE=`printf -- '- %.0s' {1..200}`
-	PROMPT_COMMAND=parse_git_branch
-	PS_INFO="$GREEN\u@\h$RESET:$BLUE\w"
+	PROMPT_COMMAND=parse_tlb_info
+	PS_LINE=`printf -- "- %.0s" {1..200}`
+	PS_FILL=${PS_LINE:0:$COLUMNS}
+	PS_INFO="$GREEN\u@\h$RESET:$BLUE\w "
+	PS_CATKIN="$YELLOW\$PS_WORKSPACE"
 	PS_GIT="$YELLOW\$PS_BRANCH"
 	PS_TIME="\[\033[\$((COLUMNS-10))G\] $RED[\t]"
-	export PS1="\${PS_FILL}\[\033[0G\]${PS_INFO} ${PS_GIT}${PS_TIME}\n${RESET}\$ "
+	export PS1="\${PS_FILL}\[\033[0G\]${PS_INFO}${PS_CATKIN}${PS_GIT}${PS_TIME}\n${RESET}\$ "
 fi

--- a/scripts/wsmux.sh
+++ b/scripts/wsmux.sh
@@ -8,9 +8,11 @@
 # user machines, if you're into that sort of thing.
 
 
+WS_MARKER=".catkin_workspace"
+
+
 _catkin_ws_complete() {
 	local FILE
-	local WS_MARKER=".catkin_workspace"
 
 	# Check for workspaces in the home directory based on the argument
 	for FILE in ~/"$2"*; do

--- a/scripts/wsmux.sh
+++ b/scripts/wsmux.sh
@@ -35,7 +35,7 @@ wsmux() {
 	while [ "$#" -gt 0 ]; do
 		case $1 in
 			-h|--help)
-				echo "Usage: wsmux CATKIN_WORKSPACE"
+				echo "Usage: wsmux [OPTION]... [CATKIN_WORKSPACE]"
 				echo "Quick catkin workspace switcher."
 				echo ""
 				echo "Option		GNU long option		Meaning"

--- a/scripts/wsmux.sh
+++ b/scripts/wsmux.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# The wsmux command makes it easy to switch between catkin workspaces. This
+# is mainly intended for use on vehicles as each user will have their own
+# workspace containing repositories that reflect their branches. In the event
+# that they need to test unmerged code in the field, they will run the node
+# from their workspace. It can also be used to manage multiple workspaces on
+# user machines, if you're into that sort of thing.
+
+
+_catkin_ws_complete() {
+	local FILE
+	local WS_MARKER=".catkin_workspace"
+
+	# Check for workspaces in the home directory based on the argument
+	for FILE in ~/"$2"*; do
+
+		# Skip any directory that does not contain the marker file
+		[[ -f $FILE/$WS_MARKER ]] || continue
+
+		# Append just the name of the workspace folder to the autocomplete list
+		COMPREPLY+=( `echo "$FILE" | rev | cut -d "/" -f1 | rev` )
+	done
+}
+
+wsmux() {
+	if [ "$1" = "-h" ] || [ "$1" = "--help" ]; then
+
+		# Print the help menu if the user passes in -h or --help
+		echo "Usage: wsmux CATKIN_WORKSPACE"
+		echo "Quick catkin workspace switcher."
+		echo ""
+		echo "Option		GNU long option		Meaning"
+		echo "-h		--help			Display the help menu"
+	else
+
+		# If the workspace was specified as a path, use it as is
+		if [ -f "$1"/devel/setup.sh ]; then
+			source "$1"/devel/setup.sh
+
+		# If a workspace name was passed, find it in the home directory
+		elif [ -f ~/"$1"/devel/setup.sh ]; then
+			source ~/"$1"/devel/setup.sh
+
+		# If neither of these were the case, informe the user that they were wrong
+		else
+			echo "The specified workspace is not valid. I don't trust like that..."
+			echo "Please specify a path or the name of a workspace in the home directory"
+		fi
+	fi
+}
+
+
+# Registers the autocompletion function to be invoked for wsmux
+complete -F _catkin_ws_complete wsmux


### PR DESCRIPTION
References to software-common were updated to point to mil_common and the rawgps-tools submodule was replaced with odometry_tools.

Some general script cleanup was done as I noticed minor style discrepancies. Nothing major was changed in `scripts/bash_aliases.sh`, `scripts/bag_backup.sh`, or `scripts/ros_connect.sh`.

Two new functions were added to bash to make operating vehicles on testing days easier. Both of these are well documented in their respective files and help commands, so this will only provide a cursory overview.

The wsmux function allows users to switch between catkin workspaces quickly (autocompletion is magic) so that each user can have their own workspace as opposed to their own user account. This will eliminate all of the issues we had with user account permissions.

The bmux function was written in response to @DSsoto's request in [NaviGator #192](https://github.com/uf-mil/NaviGator/pull/192). It allows the user to source, list, and clear the bagging aliases for a specific vehicle repository. This will prevent loading a bunch of variables into user's local shells; however, it will allow them to load the aliases if they choose to and will allow them to be loaded automatically on the actual vehicles. These variables (see the `scripts/bagging_variables.sh` file in [NaviGator #193](https://github.com/uf-mil/NaviGator/pull/193)) will be used with the bag function, which will be included in a future pull request.