### PR TITLE
SCRIPTS: Add bag and clean up configuration files

### DIFF
--- a/scripts/bag.sh
+++ b/scripts/bag.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+
+# The bag command works in tandum with the bmux command. Once the bagging
+# variables have been loaded with bmux, the bag command can be used with
+# autocompletion to select topics. It is mainly a convenience layer for
+# rosbag; however, it does introduce a few features. A list of BAG_ALWAYS
+# topics can include topics that every bag should contain, bag directory
+# management is handled cleanly, and naming bags is... strongly encouraged.
+
+
+VARIABLE_PREFIX="bag_"
+
+
+_bagging_complete() {
+	local VARIABLE
+
+	# Iterate over all of the bagging variables in the environment with the prefix removed
+	for VARIABLE in `env | grep "$VARIABLE_PREFIX$2" | cut -d"=" -f1 | sed "s@$VARIABLE_PREFIX@@"`; do
+
+		# Append the variable to the autocomplete list
+		COMPREPLY+=( "$VARIABLE" )
+	done
+}
+
+
+bag() {
+	local WORKING_DIRECTORY=$PWD
+	local MODE="bag"
+	local NAME
+	local TOPICS
+	local ARGS
+
+	# Get the list of bagging variables
+	_bagging_complete
+
+	# Handles command line arguments
+	while [ "$#" -gt 0 ]; do
+		case $1 in
+			-a|--args)
+				shift 1
+				while [ "$#" -gt 0 ]; do
+					if [ -z "$ARGS" ]; then
+						ARGS="$1"
+					else
+						ARGS="$ARGS $1"
+					fi
+					shift 1
+				done
+				;;
+			-d|--directory)
+				export BAG_DIR="$2"
+				echo "The bag storage directory is set to $BAG_DIR"
+				MODE=false
+				shift 2
+				;;
+			-g|--group)
+				if [ "$MODE" != "false" ]; then
+					MODE="group"
+				fi
+				shift 1
+				;;
+			-h|--help)
+				echo "Usage: bag [OPTION]... [BAG_VARIABLE]..."
+				echo "Manager for sourcing bagging variables for different MIL vehicles."
+				echo ""
+				echo "Option		GNU long option		Meaning"
+				echo "-a [ROSBAG_ARG]	--args			Pass arguments after to rosbag"
+				echo "-d [DIRECTORY]	--directory		Set the bag storage directory"
+				echo "-g 		--group			Group a set of existing variables"
+				echo "-h		--help			Display the help menu"
+				echo "-l		--list			List available bagging variables"
+				echo "-n [BAG_NAME]	--name			Pass a name for bags or groups"
+				echo "-s		--show			Show full bag configuration"
+				MODE=false
+				shift 1
+				;;
+			-l|--list)
+				if [ ! -z "$COMPREPLY" ]; then
+					echo "${COMPREPLY[@]}" | sed 's/ /  /g'
+				else
+					echo "No bagging variables have been loaded"
+					echo "Try 'bmux --help' for more information."
+				fi
+				MODE=false
+				shift 1
+				;;
+			-n|--name)
+				NAME="$2"
+				shift 2
+				;;
+			-s|--show)
+				if [ ! -z "$COMPREPLY" ]; then
+					echo "Bag storage directory:	$BAG_DIR"
+					echo "Always bag topics:	$BAG_ALWAYS"
+					echo ""
+					echo "Bagging variables:"
+					env | grep $VARIABLE_PREFIX
+				else
+					echo "No bagging variables have been loaded"
+					echo "Try 'bmux --help' for more information."
+				fi
+				MODE=false
+				shift 1
+				;;
+			-*)
+				echo "Option $1 is not implemented."
+				echo "Try 'bag --help' for more information."
+				MODE=false
+				shift 1
+				;;
+			*)
+				if [ "$MODE" != "false" ]; then
+					if [ ! -z "$(eval echo \$${VARIABLE_PREFIX}${1})" ] || \
+					   [ "${1:0:1}" = "/" ]; then
+						if [ -z "$TOPICS" ]; then
+							TOPICS=$(eval echo \$${VARIABLE_PREFIX}${1})
+						else
+							TOPICS="$TOPICS "$(eval echo \$${VARIABLE_PREFIX}${1})
+						fi
+					else
+						echo "$1 is not one of the available bagging aliases."
+						echo "Try 'bag --help' for more information."
+						MODE=false
+					fi
+				fi
+				shift 1
+				;;
+		esac
+	done
+
+	if [ "$MODE" != "false" ]; then
+		if [ "$MODE" = "group" ] && [ ! -z "$TOPICS" ]; then
+			while [ -z "$NAME" ]; do
+				echo -n "What should this group be called? " && read NAME
+			done
+			export "${VARIABLE_PREFIX}${NAME}"="$TOPICS"
+		elif [ "$MODE" = "bag" ]; then
+			while [ -z "$NAME" ]; do
+				echo -n "What should this bag be called? " && read NAME
+			done
+			mkdir -p $BAG_DIR"/`date +%Y-%m-%d`"
+			cd $BAG_DIR"/`date +%Y-%m-%d`"
+			rosbag record -O $NAME $ARGS $BAG_ALWAYS $TOPICS
+			cd $WORKING_DIRECTORY
+		fi
+	fi
+
+	unset COMPREPLY
+}
+
+
+# Registers the autocompletion function to be invoked for bag
+complete -F _bagging_complete bag

--- a/scripts/bag.sh
+++ b/scripts/bag.sh
@@ -14,12 +14,19 @@ VARIABLE_PREFIX="bag_"
 _bagging_complete() {
 	local VARIABLE
 
-	# Iterate over all of the bagging variables in the environment with the prefix removed
-	for VARIABLE in `env | grep "$VARIABLE_PREFIX$2" | cut -d"=" -f1 | sed "s@$VARIABLE_PREFIX@@"`; do
+	# Append all ROS topics to the autocomplete list if the string to autocomplete begins with a '/' character
+	if [ "${2:0:1}" = '/' ]; then
+		COMPREPLY+=( `rostopic list 2> /dev/null` )
 
-		# Append the variable to the autocomplete list
-		COMPREPLY+=( "$VARIABLE" )
-	done
+	else
+
+		# Otherwise, iterate over all of the bagging variables in the environment with the prefix removed
+		for VARIABLE in `env | grep "$VARIABLE_PREFIX$2" | cut -d"=" -f1 | sed "s@$VARIABLE_PREFIX@@"`; do
+
+			# Append the variable to the autocomplete list
+			COMPREPLY+=( "$VARIABLE" )
+		done
+	fi
 }
 
 
@@ -110,8 +117,7 @@ bag() {
 				;;
 			*)
 				if [ "$MODE" != "false" ]; then
-					if [ ! -z "$(eval echo \$${VARIABLE_PREFIX}${1})" ] || \
-					   [ "${1:0:1}" = "/" ]; then
+					if [ ! -z "$(eval echo \$${VARIABLE_PREFIX}${1})" ] || [ "${1:0:1}" = "/" ]; then
 						if [ -z "$TOPICS" ]; then
 							TOPICS=$(eval echo \$${VARIABLE_PREFIX}${1})
 						else

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -12,6 +12,7 @@ source $CATKIN_DIR/src/mil_common/scripts/two_line_bash.sh
 source $CATKIN_DIR/src/mil_common/scripts/ros_connect.sh
 source $CATKIN_DIR/src/mil_common/scripts/wsmux.sh
 source $CATKIN_DIR/src/mil_common/scripts/bmux.sh
+source $CATKIN_DIR/src/mil_common/scripts/bag.sh
 
 
 # Debugging for ROS networking

--- a/scripts/bmux.sh
+++ b/scripts/bmux.sh
@@ -45,7 +45,7 @@ bmux() {
 
 				# Special variables used in the bag command
 				unset BAG_ALWAYS
-				unset BAG_HOME
+				unset BAG_DIR
 				SELECTION=false
 				shift 1
 				;;

--- a/scripts/two_line_bash.sh
+++ b/scripts/two_line_bash.sh
@@ -10,10 +10,18 @@
 
 function parse_catkin_workspace {
 	PS_WORKSPACE=""
-	local WORKSPACE_DIR="`echo $ROS_PACKAGE_PATH | cut -d ':' -f1 | sed 's@/src@@'`"
-	if [ -f $WORKSPACE_DIR/.catkin_workspace ]; then
-		PS_WORKSPACE="(catkin `echo $WORKSPACE_DIR | rev | cut -d "/" -f1 | rev`) "
+
+	# Store a list of catkin workspaces in the COMPREPLY variable
+	_catkin_ws_complete
+
+	# Only print the selected workspace if more than one is present
+	if [ ${#COMPREPLY[@]} -gt 1 ]; then
+		local WORKSPACE_DIR="`echo $ROS_PACKAGE_PATH | cut -d ':' -f1 | sed 's@/src@@'`"
+		if [ -f $WORKSPACE_DIR/.catkin_workspace ]; then
+			PS_WORKSPACE="(catkin `echo $WORKSPACE_DIR | rev | cut -d "/" -f1 | rev`) "
+		fi
 	fi
+	unset COMPREPLY
 }
 
 function parse_git_branch {
@@ -32,6 +40,8 @@ function parse_git_branch {
 function parse_tlb_info {
 	parse_catkin_workspace
 	parse_git_branch
+	PS_LINE=`printf -- "- %.0s" {1..200}`
+	PS_FILL=${PS_LINE:0:$COLUMNS}
 }
 
 
@@ -43,8 +53,6 @@ if [ ! -f ~/.disable_tlb ]; then
 	YELLOW="\[\033[0;33m\]"
 
 	PROMPT_COMMAND=parse_tlb_info
-	PS_LINE=`printf -- "- %.0s" {1..200}`
-	PS_FILL=${PS_LINE:0:$COLUMNS}
 	PS_INFO="$GREEN\u@\h$RESET:$BLUE\w "
 	PS_CATKIN="$YELLOW\$PS_WORKSPACE"
 	PS_GIT="$YELLOW\$PS_BRANCH"

--- a/scripts/two_line_bash.sh
+++ b/scripts/two_line_bash.sh
@@ -5,9 +5,13 @@
 # selected branch of the git repository the user is in. While it is enabled
 # by default, two line bash can be disabled by creating a .disable_tlb file in
 # the user's home directory. This can be accomplished with the following
-# command: touch ~/.disable_tlb
+# command: echo "ENABLED=false" > ~/.mil/two_line_bash
 
 
+TLB_CONFIG_FILE=$MIL_CONFIG_DIR/two_line_bash.conf
+
+
+# Obtain the name of the currently sourced catkin workspace if more than one exist
 function parse_catkin_workspace {
 	PS_WORKSPACE=""
 
@@ -24,6 +28,7 @@ function parse_catkin_workspace {
 	unset COMPREPLY
 }
 
+# Obtain the name of the current git branch if the working directory is a git repository
 function parse_git_branch {
 	PS_BRANCH=""
 	if [ -d .svn ]; then
@@ -37,6 +42,7 @@ function parse_git_branch {
 	PS_BRANCH="(git ${ref#refs/heads/}) "
 }
 
+# Gather dynamic information for each prompt
 function parse_tlb_info {
 	parse_catkin_workspace
 	parse_git_branch
@@ -45,7 +51,13 @@ function parse_tlb_info {
 }
 
 
-if [ ! -f ~/.disable_tlb ]; then
+# Generates the configuration file if it does not exist
+if [ ! -f $TLB_CONFIG_FILE ]; then
+	echo "ENABLED=true" > $TLB_CONFIG_FILE
+fi
+
+# If two line bash is enabled, add it to the shell configuration
+if [ "`cat $TLB_CONFIG_FILE | grep ENABLED | grep -oe '[^=]*$'`" = "true" ]; then
 	RESET="\[\033[0m\]"
 	RED="\[\033[0;31m\]"
 	GREEN="\[\033[01;32m\]"


### PR DESCRIPTION
**NOTE:** Please merge [installer #5](https://github.com/uf-mil/installer/pull/5) before this.

Together, the bmux and bag commands will help streamline bagging for test days and make it less of a chore. Bagging variables are configured on a per-vehicle basis in a `scripts/bagging_variables.sh` file. See the one currently in the NaviGator repository for an example. The special BAG_DIR and BAG_ALWAYS variables specify where to store bags and topics that should be included in every bag. All other variables should be prefixed with `bag_`.

Once the aliases are loaded by bmux, they can be used with bag. The command supports autocompletion of aliases, passing extra arguments to rosbag, and even on the fly grouping (for example, creating a temporary torpedo_board variable from other variables and topics). It also *strongly encourages* users to name bags, so we shouldn't have to go on bag treasure hunts anymore.

Two line bash will now only print the sourced catkin workspace if there are more than one in `~/`.

Configuration files are now stored in one central location, under `~/.mil`. For those of you following along at home, this means you should delete `~/.disable_tlb` and `~/.ros_connect_persistence` after running the install script (if they exist on your system).