### PR TITLE
Remove Float64stamped

### DIFF
--- a/utils/mil_msgs/CMakeLists.txt
+++ b/utils/mil_msgs/CMakeLists.txt
@@ -22,7 +22,8 @@ add_message_files(FILES
   PoseTwistStamped.msg
   PoseTwist.msg
   VelocityMeasurements.msg
-  Float64Stamped.msg
+  DepthStamped.msg
+  RangeStamped.msg
   VelocityMeasurement.msg
   Acceleration.msg
 )

--- a/utils/mil_msgs/msg/DepthStamped.msg
+++ b/utils/mil_msgs/msg/DepthStamped.msg
@@ -1,0 +1,4 @@
+Header header
+
+# A depth in meters
+float64 depth

--- a/utils/mil_msgs/msg/Float64Stamped.msg
+++ b/utils/mil_msgs/msg/Float64Stamped.msg
@@ -1,2 +1,0 @@
-Header header
-float64 data

--- a/utils/mil_msgs/msg/RangeStamped.msg
+++ b/utils/mil_msgs/msg/RangeStamped.msg
@@ -1,0 +1,4 @@
+Header header
+
+# A range in meters
+float64 range


### PR DESCRIPTION
Removing the msg in mil_msgs called Float64Stamped. I created two new messages to replace it, DepthStamped and RangeStamped since it was only used for depth driver and DVL driver related things. The only other usage was in the start gate mission by @RustyBamboo, where it should be removed.

@ironmig make sure you use these as you remove the dependencies on uf_common in uf-mil/odometry_tools#3 and elsewhere.

There is no order for merging these PRs that will not break our current build, I think we might as well merge this without waiting for the other things to be completed.

Also added a section to the wiki about not using msgs or srvs void of semantic meaning.