### PR TITLE
CI: fail Jenkins build if tests dont pass

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ dockerNode(image: 'uf-mil:mil_common') {
 			source ~/.mil/milrc > /dev/null 2>&1
 			source $CATKIN_DIR/devel/setup.bash > /dev/null 2>&1
 			catkin_make -C $CATKIN_DIR run_tests
+			catkin_test_results $CATKIN_DIR/build/test_results/ --verbose
 		'''
 	}
 }


### PR DESCRIPTION
* Now runs catkin_test_results at end of test stage of build. If any tests fail, this will return exit code 1 and therefore the build will be marked as failed. It will also display a summary in the log of what test(s) failed.