### PR TITLE
Terminal input utility, Imaging sonar launch fix

### DIFF
--- a/drivers/mil_blueview_driver/launch/example.launch
+++ b/drivers/mil_blueview_driver/launch/example.launch
@@ -1,5 +1,5 @@
 <launch>
-    <node pkg="mil_blueview_driver" type="mil_blueview_driver" name="test_blue_view" >
+    <node pkg="mil_blueview_driver" type="blueview_driver" name="test_blue_view" >
         <rosparam>
             frame_id: my_sonar
             

--- a/utils/mil_tools/mil_misc_tools/__init__.py
+++ b/utils/mil_tools/mil_misc_tools/__init__.py
@@ -1,2 +1,3 @@
 from download import *
 from text_effects import *
+from terminal_input import *

--- a/utils/mil_tools/mil_misc_tools/terminal_input.py
+++ b/utils/mil_tools/mil_misc_tools/terminal_input.py
@@ -1,0 +1,28 @@
+#!/usr/env python
+import sys
+import tty
+import termios
+
+__author__ = 'David Soto'
+
+# Adapted from http://stackoverflow.com/questions/510357/python-read-a-single-character-from-the-user/21659588#21659588
+def get_ch():
+    '''
+    Gets a single character from stdin. Doesn't echo to screen
+    Catches CTRL-C and CTRL-E and raises exceptions.
+    '''
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        ch = sys.stdin.read(1)
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+    # Handle signal keys
+    if ch == '\x03': # CTRL-C
+        raise KeyboardInterrupt
+    if ch == '\x04': # CTRL-D
+        raise EOFError('Got EOF character')
+    return ch
+


### PR DESCRIPTION
* Adds utility that takes in a single character from the terminal without printing anything. (useful for programs with keyboard control, used in thruster_spin_test node in SubjuGator)
* Fixes the type used in the blueview driver example launch. (Check CMakeLists target)