### PR TITLE
SCRIPTS: Add SSH client binding to wsmux

### DIFF
--- a/scripts/bag.sh
+++ b/scripts/bag.sh
@@ -21,7 +21,7 @@ _bagging_complete() {
 	else
 
 		# Otherwise, iterate over all of the bagging variables in the environment with the prefix removed
-		for VARIABLE in $(env | grep "$VARIABLE_PREFIX$2" | cut -d"=" -f1 | sed "s@$VARIABLE_PREFIX@@"); do
+		for VARIABLE in $(env | grep "$VARIABLE_PREFIX$2" | cut -d '=' -f1 | sed "s@$VARIABLE_PREFIX@@"); do
 
 			# Append the variable to the autocomplete list
 			COMPREPLY+=( "$VARIABLE" )

--- a/scripts/bag_backup.sh
+++ b/scripts/bag_backup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script can be used to sync all new bags in the local bags directory
 # to the MIL fileserver. The autofs package can be installed and configured

--- a/scripts/bmux.sh
+++ b/scripts/bmux.sh
@@ -22,7 +22,7 @@ _bagging_variables_file_complete() {
 		if [[ -f $FILE/$BAGGING_VARIABLES_FILE ]]; then
 
 			# Append just the name of the repository to the autocomplete list
-			COMPREPLY+=( $(echo "$FILE" | rev | cut -d "/" -f1 | rev) )
+			COMPREPLY+=( $(echo "$FILE" | rev | cut -d '/' -f1 | rev) )
 		fi
 	done
 }

--- a/scripts/two_line_bash.sh
+++ b/scripts/two_line_bash.sh
@@ -20,7 +20,7 @@ parse_catkin_workspace() {
 
 	# Only print the selected workspace if more than one is present
 	if (( ${#COMPREPLY[@]} > 1 )); then
-		PS_WORKSPACE="(catkin $(echo $CATKIN_DIR | rev | cut -d "/" -f1 | rev)) "
+		PS_WORKSPACE="(catkin $(echo $CATKIN_DIR | rev | cut -d '/' -f1 | rev)) "
 	fi
 	unset COMPREPLY
 }

--- a/scripts/wsmux.sh
+++ b/scripts/wsmux.sh
@@ -101,6 +101,11 @@ wsmux() {
 						if [[ -f ~/$(echo $BINDING | cut -d ':' -f2)/devel/setup.sh ]]; then
 							SELECTION=~/$(echo $BINDING | cut -d ':' -f2)
 
+							# Source the workspace runcom file if it exists
+							if [[ -f $SELECTION/.wsrc ]]; then
+								source $SELECTION/.wsrc
+							fi
+
 						# Otherwise, prompt the user to check themself
 						else
 							echo "The specified workspace is not valid. I don't trust like that..."

--- a/scripts/wsmux.sh
+++ b/scripts/wsmux.sh
@@ -21,7 +21,7 @@ _catkin_ws_complete() {
 		if [[ -f $FILE/$WS_MARKER ]]; then
 
 			# Append just the name of the workspace folder to the autocomplete list
-			COMPREPLY+=( $(echo "$FILE" | rev | cut -d "/" -f1 | rev) )
+			COMPREPLY+=( $(echo "$FILE" | rev | cut -d '/' -f1 | rev) )
 		fi
 	done
 }
@@ -56,7 +56,7 @@ wsmux() {
 			-s|--show)
 				if [[ ! -z "$ROS_PACKAGE_PATH" ]]; then
 					echo -n "Currently sourced catkin workspace: "
-					echo "$ROS_PACKAGE_PATH" | cut -d ":" -f1 | sed "s@/src@@"
+					echo "$ROS_PACKAGE_PATH" | cut -d ':' -f1 | sed "s@/src@@"
 				else
 					echo "No catkin workspace is currently sourced"
 				fi


### PR DESCRIPTION
This implements SSH client binding for vehicles and workstations where there are multiple catkin workspaces on a user account. It will only work for situations in which the user is connecting remotely via SSH. Running `wsmux -b [WORKSPACE]` will bind the IP address of the machine you are connecting from to a specific workspace.

Running `wsmux -c` will resolve and connect to the workspace that an SSH client is bound to. This should be added to the bash runcom files of vehicles and workstations to make it automatic.

If the script detects a `.wsrc` file in the root directory of the workspace, it will be sourced when `wsmx -c` is run, but not when just `wsmux` is run. This will allow us to have user specific configurations while maintaining the ability to switch to another users workspace temporarily.