### PR TITLE
ONLINE BAGGER: Changes to allow integration with the bag command

### DIFF
--- a/utils/mil_msgs/srv/BaggerCommands.srv
+++ b/utils/mil_msgs/srv/BaggerCommands.srv
@@ -1,10 +1,11 @@
 # Directory / filename of bag_name
 # See examples below for what strings will produce what bags.
-# bag_package_path is param set when running online bagger node
+# <bag_package_path> is a ros param set when running online bagger node
+# if param is not set, <bag_package_path> = $HOME/bags/<date> (ex: /home/bob/bags/2017-04-20)
 #  /home/example/2017/    -> /home/example/2017/2017-04-24-20:51:54.bag
-#  camera_tests/test1.bag -> /bag_package_path/test1.bag
-#  my_lidar_bag           -> /bag_package_path/my_lidar_bag.bag
-#  sonar_tests/           -> /bag_package_path/sonar_tests/2017-04-24-20:51:54.bag
+#  camera_tests/test1.bag -> <bag_package_path>/camera_tests/test1.bag
+#  my_lidar_bag           -> <bag_package_path>/my_lidar_bag.bag
+#  sonar_tests/           -> <bag_package_path>/sonar_tests/2017-04-24-20:51:54.bag
 string bag_name
 
 # Space seperated list of topics to bag. If empty string, all buffered topics will be bagged

--- a/utils/mil_msgs/srv/BaggerCommands.srv
+++ b/utils/mil_msgs/srv/BaggerCommands.srv
@@ -1,4 +1,16 @@
+# Directory / filename of bag_name
+# See examples below for what strings will produce what bags.
+# bag_package_path is param set when running online bagger node
+#  /home/example/2017/    -> /home/example/2017/2017-04-24-20:51:54.bag
+#  camera_tests/test1.bag -> /bag_package_path/test1.bag
+#  my_lidar_bag           -> /bag_package_path/my_lidar_bag.bag
+#  sonar_tests/           -> /bag_package_path/sonar_tests/2017-04-24-20:51:54.bag
 string bag_name
+
+# Space seperated list of topics to bag. If empty string, all buffered topics will be bagged
+string topics
+
+# Time in seconds
 float32 bag_time
 ---
 string status

--- a/utils/mil_tools/nodes/online_bagger.py
+++ b/utils/mil_tools/nodes/online_bagger.py
@@ -55,6 +55,10 @@ class OnlineBagger(object):
         Retrieve parameters from param server.
         """
         self.dir = rospy.get_param('~bag_package_path', default=None)
+        # Handle bag directory for MIL bag script
+        if self.dir is None and os.environ.has_key('BAG_DIR'):
+            self.dir = os.environ['BAG_DIR']
+
         self.stream_time = rospy.get_param('~stream_time', default=30)  # seconds
 
         self.subscriber_list = {}

--- a/utils/mil_tools/nodes/online_bagger.py
+++ b/utils/mil_tools/nodes/online_bagger.py
@@ -54,7 +54,7 @@ class OnlineBagger(object):
         """
         Retrieve parameters from param server.
         """
-        self.dir = rospy.get_param(rospy.get_name() + '/bag_package_path', default=os.environ['HOME'])
+        self.dir = rospy.get_param(rospy.get_name() + '/bag_package_path', default=None)
         self.stream_time = rospy.get_param(rospy.get_name() + '/stream_time', default=30)  # seconds
 
         self.subscriber_list = rospy.get_param(rospy.get_name() + '/topics', default=[])
@@ -286,9 +286,14 @@ class OnlineBagger(object):
         If no bag name is provided, the current date/time is used as default.
         """
 
+        # If directory param is not set, default to $HOME/bags/<date>
+        default_dir = self.dir
+        if default_dir == None:
+            default_dir = os.path.join(os.environ['HOME'], 'bags' ,str(datetime.date.today()))
+
         # Split filename from directory
         bag_dir, bag_name = os.path.split(filename)
-        bag_dir = os.path.join(self.dir, bag_dir)
+        bag_dir = os.path.join(default_dir, bag_dir)
         if not os.path.exists(bag_dir):
             os.makedirs(bag_dir)
 

--- a/utils/mil_tools/nodes/online_bagger.py
+++ b/utils/mil_tools/nodes/online_bagger.py
@@ -43,7 +43,7 @@ class OnlineBagger(object):
         self.get_params()
         self.make_dicts()
 
-        self.bagging_service = rospy.Service('dump', BaggerCommands,
+        self.bagging_service = rospy.Service(rospy.get_name() + '/dump', BaggerCommands,
                                              self.start_bagging)
 
         self.subscribe_loop()
@@ -54,10 +54,10 @@ class OnlineBagger(object):
         """
         Retrieve parameters from param server.
         """
-        self.dir = rospy.get_param('bag_package_path', default=os.environ['HOME'])
-        self.stream_time = rospy.get_param('stream_time', default=30)  # seconds
+        self.dir = rospy.get_param(rospy.get_name() + '/bag_package_path', default=os.environ['HOME'])
+        self.stream_time = rospy.get_param(rospy.get_name() + '/stream_time', default=30)  # seconds
 
-        self.subscriber_list = rospy.get_param('topics', default=[])
+        self.subscriber_list = rospy.get_param(rospy.get_name() + '/topics', default=[])
 
         # Ensure all elements in list are a 3 element tuple
         for topic in self.subscriber_list:


### PR DESCRIPTION
* add much more configurability to where bags are placed from service call. Can now specify directory, will add .bag if not present, resolve relative directories, etc

* add topics argument to service. If not empty string, only space separated list topics will be bagged

* read BAG_ALWAYS and bag_* environment variables to get topics to buffer from bmux