### PR TITLE
BUG: Fix resubscribe period on online_bagger 

### DIFF
--- a/scripts/bag.sh
+++ b/scripts/bag.sh
@@ -291,7 +291,7 @@ bag() {
 		done
 
 		# Call to the online bagger with what topics to dump and where
-		rosservice call /online_bagger/dump "{bag_name: '$BAG_DIR/$(date +%Y-%m-%d)/$NAME', topics: '$TOPICS', bag_time: '$TIME'}"
+		rosservice call /online_bagger/dump "{bag_name: '$BAG_DIR/$(date +%Y-%m-%d)/$NAME', topics: '$TOPICS', bag_time: $TIME}"
 
 		# If the text flag was passed in, create a notes file of the same name
 		if [[ "$NOTE_TEXT" == "true" ]]; then

--- a/utils/mil_tools/launch/online_bagger_example.yaml
+++ b/utils/mil_tools/launch/online_bagger_example.yaml
@@ -1,7 +1,10 @@
 # list an arbitrary set of topics to  subscribe to and stream:
+# overwrite default stream time on specific topics in this config
 
 stream_time: 10  # seconds
 
+# adds additional topics to stream, or overrides default stream time on specific topics
+# leave blank to bag MIL bag script enviromental variables only
 topics: [["/odom",                    300] ,
          ["/absodom",                 300],
          ["/stereo/left/camera_info"     ],
@@ -11,5 +14,8 @@ topics: [["/odom",                    300] ,
          ["/velodyne_points",         300],
          ["/ooka",                    100]]
 
-# comment out if default home/user/online_bagger is desired
+# determines how frequently unavailable topics are resubscribed to defaults to 3.0 seconds:
+resubscribe_period: 3.0 # seconds
+
+# comment out if default env variable 'BAG_DIR'/current_date is desired:
 # bag_package_path: ''  

--- a/utils/mil_tools/launch/online_bagger_example.yaml
+++ b/utils/mil_tools/launch/online_bagger_example.yaml
@@ -12,10 +12,15 @@ topics: [["/odom",                    300] ,
          ["/stereo/right/camera_info", 20],
          ["/stereo/right/image_raw",   20], 
          ["/velodyne_points",         300],
-         ["/ooka",                    100]]
+         ["/tf",                    100]]
 
 # determines how frequently unavailable topics are resubscribed to defaults to 3.0 seconds:
 resubscribe_period: 3.0 # seconds
 
 # comment out if default env variable 'BAG_DIR'/current_date is desired:
-# bag_package_path: ''  
+# bag_package_path: ''
+
+# Bool parameter that determines if current date is appended to bag directory
+# for example defaults to: "home/user/bags/current-date" when True
+# else bag directory goes to: "home/user/bags when False
+dated_folder: True 


### PR DESCRIPTION
-This fixes the severe slow down of online_bagger caused by a constant attempt to resubscribe to multiple topics literally every single callback as pointed out by @ironmig:
    Added a rosparam resubscribe_period to the config 
-Fix bag.sh to provide it the correct parameters required to use online_bagger (@whispercoros)
-Fix bug related to partial bagging of available topics on edge cases (when zero or only one message is available)
-Also made improvements to output for readability