### PR TITLE
TOOLS: various script fixes, VISION: add RectFinder

### DIFF
--- a/perception/mil_vision/mil_vision_tools/__init__.py
+++ b/perception/mil_vision/mil_vision_tools/__init__.py
@@ -1,0 +1,1 @@
+from rect_finder import RectFinder

--- a/perception/mil_vision/mil_vision_tools/rect_finder.py
+++ b/perception/mil_vision/mil_vision_tools/rect_finder.py
@@ -6,6 +6,7 @@ import cv2
 
 __author__ = "Kevin Allen"
 
+
 class RectFinder(object):
     '''
     Keeps a model of a rectangle in meters, providing utility functions
@@ -28,15 +29,15 @@ class RectFinder(object):
         '''
         # Ensure length >= width
         self.width, self.length = tuple(np.sort([length, width]))
-        self.model_3D = np.array([[self.length/2.0,  -self.width/2.0, 0],
-                                  [self.length/2.0,   self.width/2.0,  0],
-                                  [-self.length/2.0,  self.width/2.0, 0],
-                                  [-self.length/2.0, -self.width/2.0, 0]], dtype=np.float)
+        self.model_3D = np.array([[self.length / 2.0, -self.width / 2.0, 0],
+                                  [self.length / 2.0, self.width / 2.0, 0],
+                                  [-self.length / 2.0, self.width / 2.0, 0],
+                                  [-self.length / 2.0, -self.width / 2.0, 0]], dtype=np.float)
         # multiplied by 10000 for 0.1mm accuracy in integer image
         self.model_2D = np.array([[[0, 0]],
-                               [[self.width*10000, 0]],
-                               [[self.width*10000, self.length*10000]],
-                               [[0, self.length*10000]]], dtype=np.int)
+                                  [[self.width * 10000, 0]],
+                                  [[self.width * 10000, self.length * 10000]],
+                                  [[0, self.length * 10000]]], dtype=np.int)
 
     @classmethod
     def from_polygon(cls, polygon):
@@ -51,9 +52,9 @@ class RectFinder(object):
         arr = rosmsg_to_numpy(polygon.points)
         # If it contains just one point, treat the x/y and length/width
         if arr.shape[0] == 1:
-            return cls(arr[:,0][0], arr[:,1][0])
+            return cls(arr[:, 0][0], arr[:, 1][0])
         else:
-            return cls(np.ptp(arr[:,0]), np.ptp(arr[:,1]))
+            return cls(np.ptp(arr[:, 0]), np.ptp(arr[:, 1]))
 
     def to_polygon(self):
         '''
@@ -77,27 +78,28 @@ class RectFinder(object):
 
         Credit to David Soto for this implementation.
         '''
+        # Work with both (n, 1, 2) and (n, 2) shaped contour representations
         if rect.shape != (rect.shape[0], 2):
             M = cv2.moments(rect)
             rect = np.reshape(rect, (rect.shape[0], 2))
         else:
             temp = rect.reshape(rect.shape[0], 1, 2)
             M = cv2.moments(temp)
-        centroid = np.array((int(M['m10']/M['m00']), int(M['m01']/M['m00'])))
+        centroid = np.array((int(M['m10'] / M['m00']), int(M['m01'] / M['m00'])))
         vectors = rect - centroid
-        atan = np.arctan2( vectors[:,1], vectors[:,0] )
+        atan = np.arctan2(vectors[:, 1], vectors[:, 0])
         atan_indicies = np.argsort(atan)
         # Sort by arctan formed by vector from centroid to each point
         rect = rect[atan_indicies]
         # If rect is horizontal, correct indicies as noted above
         if np.linalg.norm(rect[0] - rect[1]) > np.linalg.norm(rect[0] - rect[3]):
-              rect = rect[[3, 0, 1, 2]]
+            rect = rect[[3, 0, 1, 2]]
         # Print indicies onto image if debug_image is given
         if debug_image is not None:
             for i, pixel in enumerate(rect):
                 center = (int(pixel[0]), int(pixel[1]))
                 cv2.circle(debug_image, center, 5, (0, 255, 0), -1)
-                cv2.putText(debug_image, str(i), center, cv2.FONT_HERSHEY_SCRIPT_COMPLEX,1, (0,0,255))
+                cv2.putText(debug_image, str(i), center, cv2.FONT_HERSHEY_SCRIPT_COMPLEX, 1, (0, 0, 255))
         return rect
 
     def verify_contour(self, contour):
@@ -120,23 +122,26 @@ class RectFinder(object):
 
         @param epsilon_factor passed to OpenCV approx polygon function. May have to be tuned for your setup.
         @param debug_image if not None, will draw corners with text for indexes onto image
+
+        TODO: instead of using one epsilon value, iterate until a 4 sided polygon is found
         '''
-        epsilon = epsilon_factor*cv2.arcLength(contour,True)
-        polygon = cv2.approxPolyDP(contour,epsilon,True)
+        epsilon = epsilon_factor * cv2.arcLength(contour, True)
+        polygon = cv2.approxPolyDP(contour, epsilon, True)
         if len(polygon) != 4:
             return None
         return self.sort_corners(polygon, debug_image=debug_image)
 
     def get_pose_3D(self, corners, intrinsics=None, dist_coeffs=None, cam=None, rectified=False):
         '''
-        Uses the model of the object, the corosponding pixels in the image, and camera
+        Uses the model of the object, the corresponding pixels in the image, and camera
         intrinsics to estimate a 3D pose of the object.
 
         @param corners 4x2 numpy array from get_corners representing the 4 sorted corners in the image
 
         One of the two must be set:
         @param cam PinholeCameraModel object from ImageGeometry package
-        @param rectified if cam is set, set True if corners were found in an already rectified image (image_rect_color topic)
+        @param rectified if cam is set, set True if corners were found in an
+               already rectified image (image_rect_color topic)
 
         Or:
         @param instrinsics camera intrinisic matrix as numpy array
@@ -146,17 +151,17 @@ class RectFinder(object):
         between the camera and the object in meters/radians. Use cv2.Rodrigues to convert
         rvec to a 3x3 rotation matrix.
         '''
-        corners = np.array(corners,dtype=np.float)
+        corners = np.array(corners, dtype=np.float)
         # Use camera intrinsics and knowledge of marker's real demensions to get a pose estimate in camera frame
         if cam is not None:
             intrinsics = cam.intrinsicMatrix()
             if rectified:
-                dist_coeffs = np.zeros((5,1))
+                dist_coeffs = np.zeros((5, 1))
             else:
                 dist_coeffs = cam.distortionCoeffs()
         assert intrinsics is not None
         assert dist_coeffs is not None
-        _, rvec, tvec =  cv2.solvePnP(self.model_3D, corners, intrinsics, dist_coeffs)
+        _, rvec, tvec = cv2.solvePnP(self.model_3D, corners, intrinsics, dist_coeffs)
         return (tvec, rvec)
 
     def get_pose_2D(self, corners):
@@ -168,12 +173,12 @@ class RectFinder(object):
 
         @return a tuple (center, vecter)
         '''
-        top_center = (corners[1]+corners[0])/2.0
-        bot_center = (corners[2]+corners[3])/2.0
+        top_center = (corners[1] + corners[0]) / 2.0
+        bot_center = (corners[2] + corners[3]) / 2.0
         vector = top_center - bot_center
         vector = vector / np.linalg.norm(vector)
-        center = bot_center + (top_center - bot_center)/2.0
+        center = bot_center + (top_center - bot_center) / 2.0
         vector = top_center - bot_center
-        vector = vector/np.linalg.norm(vector)
+        vector = vector / np.linalg.norm(vector)
         # Store last2d as a center pixel point and unit direction vector
         return (center, vector)

--- a/perception/mil_vision/mil_vision_tools/rect_finder.py
+++ b/perception/mil_vision/mil_vision_tools/rect_finder.py
@@ -174,7 +174,7 @@ class RectFinder(object):
             if rectified:
                 dist_coeffs = np.zeros((5,1))
             else:
-                dist_coeffs = distortionCoeffs()
+                dist_coeffs = cam.distortionCoeffs()
         assert intrinsics is not None
         assert dist_coeffs is not None
         _, rvec, tvec =  cv2.solvePnP(self.model_3D, corners, intrinsics, dist_coeffs)

--- a/perception/mil_vision/mil_vision_tools/rect_finder.py
+++ b/perception/mil_vision/mil_vision_tools/rect_finder.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+import numpy as np
+from geometry_msgs.msg import Polygon
+from mil_ros_tools.msg_helpers import rosmsg_to_numpy, numpy_to_polygon
+import cv2
+
+__author__ = "Kevin Allen"
+
+class RectFinder(object):
+    def __init__(self, length=1.0, width=1.0):
+        '''
+        p[0] = Top left corner of marker         0-W-1
+        p[1] = Top right corner of marker        |   |
+                                                 L   L
+        p[2] = Bottom right corner of marker     |   |
+        p[3] = Bottom left cornet of marker      3-W-2
+        '''
+        # Ensure length >= width
+        self.width, self.length = tuple(np.sort([length, width]))
+        self.model_3D = np.array([[self.length/2.0,  -self.width/2.0, 0],
+                                  [self.length/2.0,   self.width/2.0,  0],
+                                  [-self.length/2.0,  self.width/2.0, 0],
+                                  [-self.length/2.0, -self.width/2.0, 0]], dtype=np.float)
+        # multiplied by 10000 for 0.1mm accuracy in integer image
+        self.model_2D = np.array([[[0, 0]],
+                               [[self.width*10000, 0]],
+                               [[self.width*10000, self.length*10000]],
+                               [[0, self.length*10000]]], dtype=np.int)
+
+    @classmethod
+    def from_polygon(cls, polygon):
+        assert isinstance(polygon, Polygon)
+        arr = rosmsg_to_numpy(polygon.points)
+        if arr.shape[0] == 1:
+            return cls(arr[:,0][0], arr[:,1][0])
+        else:
+            return cls(np.ptp(arr[:,0]), np.ptp(arr[:,1]))
+
+    def to_polygon(self):
+        return numpy_to_polygon(self.model_3D)
+
+    @staticmethod
+    def sort_corners(rect, debug_image=None):
+        '''
+        Given a contour of 4 points, returns the same 4 points sorted in a known way.
+        Used so that indicies of contour line up to that in model for cv2.solvePnp
+        p[0] = Top left corner of marker         0--1
+        p[1] = Top right corner of marker        |  |
+        p[2] = Bottom right corner of marker     |  |
+        p[3] = Bottom left cornet of marker      3--2
+
+        The implementation of this is a little bit of magic, and there may be an easier way
+        to do this. For now you can just see it as a black box, which takes four corners
+        of the path marker and returns the same four corners in a known order
+        '''
+        if rect.shape != (rect.shape[0], 2):
+            rect = np.reshape(rect, (rect.shape[0], 2))
+        sorted_x = np.argsort(rect[:,0])
+        sorted_y = np.argsort(rect[:,1])
+        # Wrap index around from 3 to 0
+        def ind_next(i):
+            if i >= 3:
+              return 0
+            return i+1
+        # Given two correct corner indexes, get other 2
+        def get_two(a, b):
+            if a - b == 1: # Ex: (1,0) -> (3,2)
+                return (ind_next(ind_next(a)), ind_next(a))
+            elif a - b == -1: # Ex: (0, 1) -> (2,3)
+                return (ind_next(b), ind_next(ind_next(b)))
+            elif a - b == 3:
+                return (1,2)
+            elif a - b == -3:
+                return (2,1)
+
+        # Horizontal orientation
+        if np.linalg.norm(rect[sorted_y[0]] - rect[sorted_y[1]]) >  np.linalg.norm(rect[sorted_y[0]] - rect[sorted_y[2]]):
+            # If 1 is lower than 0, reverse
+            if rect[sorted_x[1]][1] > rect[sorted_x[0]][1]:
+                sorted_x[0], sorted_x[1] = sorted_x[1].copy(), sorted_x[0].copy()
+            next_two = get_two(sorted_x[0], sorted_x[1])
+            sorted_x[2], sorted_x[3] = next_two[0], next_two[1]
+            rect = np.array([rect[sorted_x[0]], rect[sorted_x[1]], rect[sorted_x[2]], rect[sorted_x[3]]])
+        else:
+            # If 1 is to the left of zero, reverse
+            if rect[sorted_y[0]][0] > rect[sorted_y[1]][0]:
+                sorted_y[0], sorted_y[1] = sorted_y[1].copy(), sorted_y[0].copy()
+            next_two = get_two(sorted_y[0], sorted_y[1])
+            sorted_y[2], sorted_y[3] = next_two[0], next_two[1]
+            rect = np.array([rect[sorted_y[0]], rect[sorted_y[1]], rect[sorted_y[2]], rect[sorted_y[3]]])
+        if debug_image is not None:
+            for i, pixel in enumerate(rect):
+                center = (int(pixel[0]), int(pixel[1]))
+                cv2.circle(debug_image, center, 5, (0, 255, 0), -1)
+                cv2.putText(debug_image, str(i), center, cv2.FONT_HERSHEY_SCRIPT_COMPLEX,1, (0,0,255))
+        return rect
+
+    def verify_contour(self, contour):
+        '''
+        Does various tests to filter out contours that are clearly not
+        a valid path marker.
+        * run approx polygon, check that sides == 4
+        * find ratio of length to width, check close to known ratio IRL
+        '''
+        return cv2.matchShapes(contour, self.model_2D, 3, 0.0)
+
+    def get_corners(self, contour, epsilon_factor=0.1, debug_image=None):
+        epsilon = epsilon_factor*cv2.arcLength(contour,True)
+        polygon = cv2.approxPolyDP(contour,epsilon,True)
+        if len(polygon) != 4:
+            return None
+        return self.sort_corners(polygon, debug_image=debug_image)
+
+    def get_pose_3D(self, corners, intrinsics=None, dist_coeffs=None, cam=None, rectified=False):
+        corners = np.array(corners,dtype=np.float)
+        # Use camera intrinsics and knowledge of marker's real demensions to get a pose estimate in camera frame
+        if cam is not None:
+            intrinsics = cam.intrinsicMatrix()
+            if rectified:
+                dist_coeffs = np.zeros((5,1))
+            else:
+                dist_coeffs = distortionCoeffs()
+        assert intrinsics is not None
+        assert dist_coeffs is not None
+        _, rvec, tvec =  cv2.solvePnP(self.model_3D, corners, intrinsics, dist_coeffs)
+        return (tvec, rvec)
+
+    def get_pose_2D(self, corners):
+        '''
+        Given a sorted 4 sided polygon, stores the centroid and angle
+        for the next service call to get 2dpose.
+        '''
+        top_center = (corners[1]+corners[0])/2.0
+        bot_center = (corners[2]+corners[3])/2.0
+        vector = top_center - bot_center
+        vector = vector / np.linalg.norm(vector)
+        center = bot_center + (top_center - bot_center)/2.0
+        vector = top_center - bot_center
+        vector = vector/np.linalg.norm(vector)
+        # Store last2d as a center pixel point and unit direction vector
+        return (center, vector)

--- a/perception/mil_vision/setup.py
+++ b/perception/mil_vision/setup.py
@@ -5,7 +5,7 @@ from catkin_pkg.python_setup import generate_distutils_setup
 
 # fetch values from package.xml
 setup_args = generate_distutils_setup(
-    packages=[''],
+    packages=['mil_vision_tools'],
 )
 
 setup(**setup_args)

--- a/utils/mil_msgs/CMakeLists.txt
+++ b/utils/mil_msgs/CMakeLists.txt
@@ -30,6 +30,7 @@ add_message_files(FILES
 add_service_files(FILES
   CameraToLidarTransform.srv
   BaggerCommands.srv
+  SetGeometry.srv
 )
 
 generate_messages(

--- a/utils/mil_msgs/srv/SetGeometry.srv
+++ b/utils/mil_msgs/srv/SetGeometry.srv
@@ -1,0 +1,4 @@
+geometry_msgs/Polygon model
+---
+bool success
+string message

--- a/utils/mil_tools/mil_ros_tools/fix_bag.py
+++ b/utils/mil_tools/mil_ros_tools/fix_bag.py
@@ -2,91 +2,90 @@
 import argparse
 import rosbag
 import rospy
-from sensor_msgs.msg import CameraInfo
-from roslib.message import get_message_class
+
 
 class BagFixer():
-  '''
-  Dictionary of topics to remap. If ends in /, remaps everything after
-  Otherwise, topic must match exactly
-  '''
-  def fix_topic(self, topic):
-      for k, t in self.topic_map.iteritems():
-          if topic.find(k) == 0:
-              return t+topic[len(k):]
-      return topic
+    '''
+    Dictionary of topics to remap. If ends in /, remaps everything after
+    Otherwise, topic must match exactly
+    '''
+    def fix_topic(self, topic):
+        for k, t in self.topic_map.iteritems():
+            if topic.find(k) == 0:
+                return t + topic[len(k):]
+        return topic
 
-  def fix_tf(self, tf):
-      for i, t in enumerate(tf.transforms):
-          tf.transforms[i].header.frame_id = self.fix_frame(tf.transforms[i].header.frame_id)
-          tf.transforms[i].child_frame_id = self.fix_frame(tf.transforms[i].child_frame_id)
-      return tf
+    def fix_tf(self, tf):
+        for i, t in enumerate(tf.transforms):
+            tf.transforms[i].header.frame_id = self.fix_frame(tf.transforms[i].header.frame_id)
+            tf.transforms[i].child_frame_id = self.fix_frame(tf.transforms[i].child_frame_id)
+        return tf
 
-  def fix_frame(self, frame):
-      fixed_frame = self.frame_map.get(frame)
-      return fixed_frame if fixed_frame != None else frame
+    def fix_frame(self, frame):
+        fixed_frame = self.frame_map.get(frame)
+        return fixed_frame if fixed_frame is not None else frame
 
-  def fix_bag(self, infile, outfile=None):
-      if outfile == None:
-          split = infile.rsplit('.bag', 1)
-          outfile = split[0]+'_fixed.bag'
-      out = rosbag.Bag(outfile, 'w')
-      try:
-          bag = rosbag.Bag(infile)
-      except rosbag.bag.ROSBagException as e:
-          print "Error opening bag {}: {}".format(infile, e)
-          return
-      _, _, first_time = bag.read_messages().next()
-      assert(first_time is not None)
-      start, stop = None, None
-      if self.start is not None:
-          start = first_time + rospy.Duration(self.start)
-      if self.stop is not None:
-          stop = first_time + rospy.Duration(self.stop)
-      # This could be made signifigantly faster by using ag.get_type_and_topic_info
-      # to do some preprocessing on what topics will be used / remaped / processed
-      for topic, msg, time in bag.read_messages(start_time=start, end_time=stop):
-        if not self.valid_topic(topic):
-            continue
-        topic = self.fix_topic(topic)
-        if hasattr(msg, 'header') and msg.header._type == 'std_msgs/Header':
-          msg.header.frame_id = self.fix_frame(msg.header.frame_id)
-        if msg._type == 'tf2_msgs/TFMessage' or msg._type == 'tf/tfMessage':
-          msg = self.fix_tf(msg)
-        out.write(topic, msg, time)
-      out.flush()
-      out.close()
+    def fix_bag(self, infile, outfile=None):
+        if outfile is None:
+            split = infile.rsplit('.bag', 1)
+            outfile = split[0] + '_fixed.bag'
+        out = rosbag.Bag(outfile, 'w')
+        try:
+            bag = rosbag.Bag(infile)
+        except rosbag.bag.ROSBagException as e:
+            print "Error opening bag {}: {}".format(infile, e)
+            return
+        _, _, first_time = bag.read_messages().next()
+        assert(first_time is not None)
+        start, stop = None, None
+        if self.start is not None:
+            start = first_time + rospy.Duration(self.start)
+        if self.stop is not None:
+            stop = first_time + rospy.Duration(self.stop)
+        # This could be made signifigantly faster by using ag.get_type_and_topic_info
+        # to do some preprocessing on what topics will be used / remaped / processed
+        for topic, msg, time in bag.read_messages(start_time=start, end_time=stop):
+            if not self.valid_topic(topic):
+                continue
+            topic = self.fix_topic(topic)
+            if hasattr(msg, 'header') and msg.header._type == 'std_msgs/Header':
+                msg.header.frame_id = self.fix_frame(msg.header.frame_id)
+            if msg._type == 'tf2_msgs/TFMessage' or msg._type == 'tf/tfMessage':
+                msg = self.fix_tf(msg)
+            out.write(topic, msg, time)
+        out.flush()
+        out.close()
 
-  def _fix_strings(self, strings):
-      if type(strings) == dict:
-          return strings
-      d = {}
-      if strings is None:
-          return d
-      assert type(strings) == list
-      for s in strings:
-        split = s.split(':')
-        assert len(split) == 2
-        d[split[0]] = split[1]
-      return d
+    def _fix_strings(self, strings):
+        if type(strings) == dict:
+            return strings
+        d = {}
+        if strings is None:
+            return d
+        assert type(strings) == list
+        for s in strings:
+            split = s.split(':')
+            assert len(split) == 2
+            d[split[0]] = split[1]
+        return d
 
-  def valid_topic(self, topic):
-      if topic in self.ignore_topics:
-          return false
-      if self.keep_topics is not None and len(self.keep_topics):
-          for t in self.keep_topics:
-              if topic.find(t) == 0:
-                  return True
-          return False
-      return True
+    def valid_topic(self, topic):
+        if topic in self.ignore_topics:
+            return False
+        if self.keep_topics is not None and len(self.keep_topics):
+            for t in self.keep_topics:
+                if topic.find(t) == 0:
+                    return True
+            return False
+        return True
 
-  def __init__(self, topic_map={}, frame_map={}, start=None, stop=None, keep=[], ignore=[]):
-      self.topic_map = self._fix_strings(topic_map)
-      self.frame_map = self._fix_strings(frame_map)
-      self.start = start
-      self.stop = stop
-      self.keep_topics = keep if keep is not None else []
-      self.ignore_topics = ignore if keep is not None else []
+    def __init__(self, topic_map={}, frame_map={}, start=None, stop=None, keep=[], ignore=[]):
+        self.topic_map = self._fix_strings(topic_map)
+        self.frame_map = self._fix_strings(frame_map)
+        self.start = start
+        self.stop = stop
+        self.keep_topics = keep if keep is not None else []
+        self.ignore_topics = ignore if keep is not None else []
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Fix bag topics/frame_ids')
@@ -94,19 +93,22 @@ if __name__ == "__main__":
                         help='Bag to read and fix')
     parser.add_argument('--out', '-o', type=str, dest='outfile',
                         help='Bag to output with fixed content, defaults to INPUTFILENAME_fixed.bag')
-    parser.add_argument('--remap-topics', dest='topics', required=False, nargs='+', type=str, metavar='oldtopic:newtopic',
-                          help="list of topics to remap, seperated by a colon, ex /down_cam/:/camera/down/ /my_odom:/odom\
-                          If ends in a slash (ex: /cameras/:/cams/, all topics after slash will be remaped")
-    parser.add_argument('--remap-frames', dest='frames', required=False, nargs='+', type=str, metavar='oldframe:newframe',
-                          help="list of frame_ids in headers to be maped, ex: my_camera:cam_front")
-    parser.add_argument('--start',required=False, type=float, metavar='TIME',
-                          help="duration in bag, in seconds, to start output bag")
-    parser.add_argument('--stop',required=False, type=float, metavar='TIME',
-                          help="duration in bag, in seconds, to stop output bag")
+    parser.add_argument('--remap-topics', dest='topics', required=False, nargs='+', type=str,
+                        metavar='oldtopic:newtopic',
+                        help="list of topics to remap, seperated by a colon, ex /down_cam/:/camera/down/\
+                              /my_odom:/odom\nIf ends in a slash (ex: /cameras/:/cams/,\
+                              all topics after slash will be remaped")
+    parser.add_argument('--remap-frames', dest='frames', required=False, nargs='+', type=str,
+                        metavar='oldframe:newframe',
+                        help="list of frame_ids in headers to be maped, ex: my_camera:cam_front")
+    parser.add_argument('--start', required=False, type=float, metavar='TIME',
+                        help="duration in bag, in seconds, to start output bag")
+    parser.add_argument('--stop', required=False, type=float, metavar='TIME',
+                        help="duration in bag, in seconds, to stop output bag")
     parser.add_argument('--keep-topics', dest='keep_topics', required=False, nargs='+', type=str, metavar='topic',
-                          help="if used, output bag will contain only this list of topics")
+                        help="if used, output bag will contain only this list of topics")
     parser.add_argument('--ignore-topics', dest='ignore_topics', required=False, nargs='+', type=str, metavar='topic',
-                          help="if used, output bag will not contain these topics")
+                        help="if used, output bag will not contain these topics")
 
     args = parser.parse_args()
     if args.keep_topics and args.ignore_topics:
@@ -116,5 +118,3 @@ if __name__ == "__main__":
                      start=args.start, stop=args.stop,
                      keep=args.keep_topics, ignore=args.ignore_topics)
     fixer.fix_bag(args.infile, args.outfile)
-  
-  

--- a/utils/mil_tools/mil_ros_tools/fix_bag.py
+++ b/utils/mil_tools/mil_ros_tools/fix_bag.py
@@ -55,6 +55,7 @@ class BagFixer():
           msg = self.fix_tf(msg)
         out.write(topic, msg, time)
       out.flush()
+      out.close()
 
   def _fix_strings(self, strings):
       if type(strings) == dict:

--- a/utils/mil_tools/mil_ros_tools/fix_bag.py
+++ b/utils/mil_tools/mil_ros_tools/fix_bag.py
@@ -25,14 +25,29 @@ class BagFixer():
   def fix_frame(self, frame):
       fixed_frame = self.frame_map.get(frame)
       return fixed_frame if fixed_frame != None else frame
-      
+
   def fix_bag(self, infile, outfile=None):
       if outfile == None:
           split = infile.rsplit('.bag', 1)
           outfile = split[0]+'_fixed.bag'
       out = rosbag.Bag(outfile, 'w')
-      bag = rosbag.Bag(infile)
-      for topic, msg, time in bag.read_messages():
+      try:
+          bag = rosbag.Bag(infile)
+      except rosbag.bag.ROSBagException as e:
+          print "Error opening bag {}: {}".format(infile, e)
+          return
+      _, _, first_time = bag.read_messages().next()
+      assert(first_time is not None)
+      start, stop = None, None
+      if self.start is not None:
+          start = first_time + rospy.Duration(self.start)
+      if self.stop is not None:
+          stop = first_time + rospy.Duration(self.stop)
+      # This could be made signifigantly faster by using ag.get_type_and_topic_info
+      # to do some preprocessing on what topics will be used / remaped / processed
+      for topic, msg, time in bag.read_messages(start_time=start, end_time=stop):
+        if not self.valid_topic(topic):
+            continue
         topic = self.fix_topic(topic)
         if hasattr(msg, 'header') and msg.header._type == 'std_msgs/Header':
           msg.header.frame_id = self.fix_frame(msg.header.frame_id)
@@ -40,24 +55,37 @@ class BagFixer():
           msg = self.fix_tf(msg)
         out.write(topic, msg, time)
       out.flush()
-    
-  def fix_strings(self, strings):
+
+  def _fix_strings(self, strings):
       if type(strings) == dict:
           return strings
-      assert type(strings) == list
       d = {}
+      if strings is None:
+          return d
+      assert type(strings) == list
       for s in strings:
         split = s.split(':')
         assert len(split) == 2
         d[split[0]] = split[1]
       return d
-        
-  def __init__(self, topic_map={}, frame_map={}):
-      self.topic_map = self.fix_strings(topic_map)
-      self.frame_map = self.fix_strings(frame_map)
-      print self.topic_map
-      print self.frame_map
-      #self.fix_bag()
+
+  def valid_topic(self, topic):
+      if topic in self.ignore_topics:
+          return false
+      if self.keep_topics is not None and len(self.keep_topics):
+          for t in self.keep_topics:
+              if topic.find(t) == 0:
+                  return True
+          return False
+      return True
+
+  def __init__(self, topic_map={}, frame_map={}, start=None, stop=None, keep=[], ignore=[]):
+      self.topic_map = self._fix_strings(topic_map)
+      self.frame_map = self._fix_strings(frame_map)
+      self.start = start
+      self.stop = stop
+      self.keep_topics = keep if keep is not None else []
+      self.ignore_topics = ignore if keep is not None else []
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Fix bag topics/frame_ids')
@@ -65,14 +93,27 @@ if __name__ == "__main__":
                         help='Bag to read and fix')
     parser.add_argument('--out', '-o', type=str, dest='outfile',
                         help='Bag to output with fixed content, defaults to INPUTFILENAME_fixed.bag')
-    parser.add_argument('--topics',required=False, nargs='+', type=str, metavar='oldtopic:newtopic',
+    parser.add_argument('--remap-topics', dest='topics', required=False, nargs='+', type=str, metavar='oldtopic:newtopic',
                           help="list of topics to remap, seperated by a colon, ex /down_cam/:/camera/down/ /my_odom:/odom\
                           If ends in a slash (ex: /cameras/:/cams/, all topics after slash will be remaped")
-    parser.add_argument('--frames',required=False, nargs='+', type=str, metavar='oldframe:newframe',
+    parser.add_argument('--remap-frames', dest='frames', required=False, nargs='+', type=str, metavar='oldframe:newframe',
                           help="list of frame_ids in headers to be maped, ex: my_camera:cam_front")
+    parser.add_argument('--start',required=False, type=float, metavar='TIME',
+                          help="duration in bag, in seconds, to start output bag")
+    parser.add_argument('--stop',required=False, type=float, metavar='TIME',
+                          help="duration in bag, in seconds, to stop output bag")
+    parser.add_argument('--keep-topics', dest='keep_topics', required=False, nargs='+', type=str, metavar='topic',
+                          help="if used, output bag will contain only this list of topics")
+    parser.add_argument('--ignore-topics', dest='ignore_topics', required=False, nargs='+', type=str, metavar='topic',
+                          help="if used, output bag will not contain these topics")
+
     args = parser.parse_args()
-    fixer = BagFixer(args.topics, args.frames)
+    if args.keep_topics and args.ignore_topics:
+        parser.error('Only --keep-topics or --ignore-topics can be used at once')
+
+    fixer = BagFixer(topic_map=args.topics, frame_map=args.frames,
+                     start=args.start, stop=args.stop,
+                     keep=args.keep_topics, ignore=args.ignore_topics)
     fixer.fix_bag(args.infile, args.outfile)
-    #fixer = BagFixer(args.inbag, args.outbag)
   
   

--- a/utils/mil_tools/mil_ros_tools/label_me_bag.py
+++ b/utils/mil_tools/mil_ros_tools/label_me_bag.py
@@ -317,6 +317,7 @@ class BagToLabelMe():
                         out.write(topic+'/labels', labels, t)
             out.write(topic, msg, t)
           out.flush()
+          out.close()
       else:
           _, _, first_time = bag.read_messages().next()
           for segment in bag_config['segments']:
@@ -337,6 +338,8 @@ class BagToLabelMe():
                               out.write(topic+'/labels', labels, t)
                   out.write(topic, msg, t)
               out.flush()
+              out.close()
+      bag.close()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Generates rosbags based on LabelMe data and visa/versa')

--- a/utils/mil_tools/mil_ros_tools/label_me_bag.py
+++ b/utils/mil_tools/mil_ros_tools/label_me_bag.py
@@ -25,327 +25,332 @@ import os
 import rosbag
 import rospy
 import cv2
-import genpy
 from cv_bridge import CvBridge
 from geometry_msgs.msg import Point
 from mil_msgs.msg import LabeledObjects, LabeledObject
 
+
 class BagToLabelMe():
-  """
-  Interfaces between ROS bags and LabelMe images.
-  
-  Can be used to insert images from ROS bags into LabelMe instalation
-  or extract LabelMe annotations into a ROS bag
-  
-  TODO: improve verbosity, disable print statements with toggle
-  """
-  def __init__(self, config, labelme_dir, verbose=False, indir='', outdir=''):
-      """
-      Generates class that can be used to insert or extract images to/from LabelMe
-      
-      config: path to YAML file following format of the example yaml file in this package
-      labelme_dir: root directory of labelme instalation (should contain Images and Annotations directories)
-      """
-      self.verbose = verbose
-      if not os.path.isdir(labelme_dir):
-          raise Exception("Labelme directory {} does not exsist".format(labelme_dir))
+    """
+    Interfaces between ROS bags and LabelMe images.
 
-      config_file = open(config, 'r')
-      self.config = yaml.load(config_file)
-      self._verify_yaml()
-      self.bridge = CvBridge()
-      self.labelme_dir = labelme_dir
-      self.indir = indir
-      self.outdir = outdir
+    Can be used to insert images from ROS bags into LabelMe instalation
+    or extract LabelMe annotations into a ROS bag
 
-  def _print(self, string,*args):
-      if self.verbose:
-          print string.format(*args)
+    TODO: improve verbosity, disable print statements with toggle
+    """
+    def __init__(self, config, labelme_dir, verbose=False, indir='', outdir=''):
+        """
+        Generates class that can be used to insert or extract images to/from LabelMe
 
-  def _verify_yaml(self):
-      """
-      Called by constructor to ensure YAML follows correct format.
+        config: path to YAML file following format of the example yaml file in this package
+        labelme_dir: root directory of labelme instalation (should contain Images and Annotations directories)
+        """
+        self.verbose = verbose
+        if not os.path.isdir(labelme_dir):
+            raise Exception("Labelme directory {} does not exsist".format(labelme_dir))
 
-      TODO: Improve this process, perhaps using the YAML library more extensiviely
-      """
-      def verify_attr(obj, attr, objname, throw=True):
-          if not throw:
-              return attr in obj
-          if not attr in obj:
-              raise Exception("{} does not have required attribute {} in config".format(objname, attr))
-      verify_attr(self.config, 'bags', 'Config')
-      self._print('Pulling segments from {} bag(s):', len(self.config['bags']))
-      for i, bag in enumerate(self.config['bags']):
-          verify_attr(bag, 'file', 'Bag')
-          if not 'file' in bag:
-              raise Exception("Bag does not contain 'file' attribute {}".format(bag))
-          verify_attr(bag, 'segments', bag['file'])
-          if not bag.has_key('combined'):
-              self.config['bags'][i]['combined'] = False
-          self._print('\tFound {} segments for {}:', len(bag['segments']), bag['file'])
-          for j, segment in enumerate(bag['segments']):
-              verify_attr(segment, 'topics', 'segment')
-              # Ensure topics is still a list
-              if type(segment['topics']) == str:
-                  self.config['bags'][i]['segments'][j]['topics'] = [segment]
-              verify_attr(segment, 'name', 'segment')
-              self._print("\t\tFound segment '{}' of topics '{}' from {} to {} every {}",
-                          segment['name'], segment['topics'],
-                          segment['start'] if segment.has_key('start') else 'start',
-                          segment['stop'] if segment.has_key('stop') else 'stop',
-                          str(segment['freq']) + ' seconds' if segment.has_key('freq') else 'frame')
+        config_file = open(config, 'r')
+        self.config = yaml.load(config_file)
+        self._verify_yaml()
+        self.bridge = CvBridge()
+        self.labelme_dir = labelme_dir
+        self.indir = indir
+        self.outdir = outdir
 
-  def read_bags(self):
-      """
-      Crawls through all bags in config YAML, placing images from the specified
-      topics and the specified frequency into corresponding folders within
-      Images of the labelme instalation.
-      
-      These folders will be created as follows if not already:
-      LABELME_DIR/Images/SEGEMENT_NAME/TOPIC_NAME
-      where TOPIC_NAME replaces all / with @ for compatibility with filesystems.
-      """
-      for bag in self.config['bags']:
-          self._print("Opening {}", bag['file'])
-          self._read_bag(bag['file'], bag['segments'])
+    def _print(self, string, *args):
+        if self.verbose:
+            print string.format(*args)
 
-  def extract_labels(self):
-      """
-      Finds labeled XML files in LabelMe directories determined from the
-      config file, placing parsed annotation data as ros messages in a new bag
-      """
-      self._print("Extracting labels for all bags in config")
-      for bag in self.config['bags']:
-          self._print("\tExtracting LabelMe annotations for {}".format(bag['file']))
-          self._extract_labels_bag(bag)
+    def _verify_yaml(self):
+        """
+        Called by constructor to ensure YAML follows correct format.
 
-  def print_report(self):
-      """
-      Compares how many images are present in each LabelMe directory affected
-      by the config YAML to the number of annotated XML files produced by
-      LabelMe in each of these directories.
-      
-      Prints out these counts in percentages by segement, bag, and overall
-      """
-      self._print("Generating completion report for all bags in config")
-      total_xml_count = 0
-      total_img_count = 0
-      for bag in self.config['bags']:
-          self._print("\tGenerating completion report for {}", bag['file'])
-          x, i = self._print_bag_report(bag)
-          total_xml_count += x
-          total_img_count += i
-      if total_img_count == 0:
-          print "{}/{} TOTAL images labeled (0%)".format(total_xml_count, total_img_count)
-      else:
-          print "{}/{} TOTAL images labeled ({:.1%})".format(total_xml_count, total_img_count, total_xml_count/total_img_count)
+        TODO: Improve this process, perhaps using the YAML library more extensiviely
+        """
+        def verify_attr(obj, attr, objname, throw=True):
+            if not throw:
+                return attr in obj
+            if attr not in obj:
+                raise Exception("{} does not have required attribute {} in config".format(objname, attr))
+        verify_attr(self.config, 'bags', 'Config')
+        self._print('Pulling segments from {} bag(s):', len(self.config['bags']))
+        for i, bag in enumerate(self.config['bags']):
+            verify_attr(bag, 'file', 'Bag')
+            if 'file' not in bag:
+                raise Exception("Bag does not contain 'file' attribute {}".format(bag))
+            verify_attr(bag, 'segments', bag['file'])
+            if 'combined' not in bag:
+                self.config['bags'][i]['combined'] = False
+            self._print('\tFound {} segments for {}:', len(bag['segments']), bag['file'])
+            for j, segment in enumerate(bag['segments']):
+                verify_attr(segment, 'topics', 'segment')
+                # Ensure topics is still a list
+                if type(segment['topics']) == str:
+                    self.config['bags'][i]['segments'][j]['topics'] = [segment]
+                verify_attr(segment, 'name', 'segment')
+                self._print("\t\tFound segment '{}' of topics '{}' from {} to {} every {}",
+                            segment['name'], segment['topics'],
+                            segment['start'] if 'start' in segment else 'start',
+                            segment['stop'] if 'stop' in segment else 'stop',
+                            str(segment['freq']) + ' seconds' if 'freq' in segment else 'frame')
 
-  def _read_bag(self, bagfile, segments):
-      """
-      Crawls through a single bag specified in the config YAML, placing
-      images into the Images/ directory of labelme.
-      
-      Called me read_bags for each bag in YAML
-      """
-      bag = self._get_input_bag(bagfile)
-      _, _, first_time = bag.read_messages().next()
-      for segment in segments:
-          self._print("\tProccessing Segment '{}'",segment['name'])
-          # Put images in LABELMEDIR/Images/SEGMENTNAME/TOPIC, where TOPIC replaces / with @
-          paths = {}
-          for t in segment['topics']:
-              path = os.path.join(self.labelme_dir, 'Images', segment['name'].replace('/', '@'), t.replace('/', '@'))
-              if not os.path.exists(path):
-                  os.makedirs(path)
-              paths[t] = path
-          # Ensure start and stop are passed as None to read_messages if not defined
-          start = None
-          stop = None
-          interval = rospy.Duration(0)
-          if segment.has_key('start'):
-              start = first_time + rospy.Duration(segment['start'])
-          if segment.has_key('stop'):
-              stop = first_time + rospy.Duration(segment['stop'])
-          if segment.has_key('freq'):
-              interval = rospy.Duration(1.0 / segment['freq'])
-          next_time = start if start is not None else rospy.Time(0)
-          # Crawl through bag between start and stop time at freq
-          for topic, msg, time in bag.read_messages(topics=segment['topics'], start_time = start, end_time = stop):
-              if time >= next_time:
-                  # If enough time has elapsed, put an image in this segment's directory,
-                  # named by the frame's timestamp converted to a string: str(ros.Time(stamp))
-                  img = self.bridge.imgmsg_to_cv2(msg, desired_encoding="passthrough")
-                  filename = os.path.join(paths[topic], str(msg.header.stamp) + '.jpg')
-                  cv2.imwrite(filename, img)
-                  next_time = next_time + interval
-      
-  def _print_bag_report(self, bagconfig):
-      """
-      Compares number of labeled XML files in LabelMe for a given
-      bag specified in YAML config to number of images in LabelMe for this
-      bag.
-      
-      If verbose is enabled, prints info for each segment. Otherwise,
-      just returns total counts.
-      
-      Called by print_report for each bag in config.
-      """
-      total_xml_count = 0
-      total_img_count = 0
-      for segment in bagconfig['segments']:
-          self._print("\t\tGenerating Report for segment '{}'",segment['name'])
-          xml_count = 0
-          img_count = 0
-          for t in segment['topics']:
-              xml_path = os.path.join(self.labelme_dir, 'Annotations', segment['name'].replace('/', '@'), t.replace('/', '@'))
-              img_path = os.path.join(self.labelme_dir, 'Images', segment['name'].replace('/', '@'), t.replace('/', '@'))
-              if os.path.isdir(xml_path):
-                  for xmlfile in os.listdir(xml_path):
-                      xml_count += 1
-              if os.path.isdir(img_path):
-                  for imgfile in os.listdir(img_path):
-                      img_count += 1
-          if img_count == 0:
+    def read_bags(self):
+        """
+        Crawls through all bags in config YAML, placing images from the specified
+        topics and the specified frequency into corresponding folders within
+        Images of the labelme instalation.
+
+        These folders will be created as follows if not already:
+        LABELME_DIR/Images/SEGEMENT_NAME/TOPIC_NAME
+        where TOPIC_NAME replaces all / with @ for compatibility with filesystems.
+        """
+        for bag in self.config['bags']:
+            self._print("Opening {}", bag['file'])
+            self._read_bag(bag['file'], bag['segments'])
+
+    def extract_labels(self):
+        """
+        Finds labeled XML files in LabelMe directories determined from the
+        config file, placing parsed annotation data as ros messages in a new bag
+        """
+        self._print("Extracting labels for all bags in config")
+        for bag in self.config['bags']:
+            self._print("\tExtracting LabelMe annotations for {}".format(bag['file']))
+            self._extract_labels_bag(bag)
+
+    def print_report(self):
+        """
+        Compares how many images are present in each LabelMe directory affected
+        by the config YAML to the number of annotated XML files produced by
+        LabelMe in each of these directories.
+
+        Prints out these counts in percentages by segement, bag, and overall
+        """
+        self._print("Generating completion report for all bags in config")
+        total_xml_count = 0
+        total_img_count = 0
+        for bag in self.config['bags']:
+            self._print("\tGenerating completion report for {}", bag['file'])
+            x, i = self._print_bag_report(bag)
+            total_xml_count += x
+            total_img_count += i
+        if total_img_count == 0:
+            print "{}/{} TOTAL images labeled (0%)".format(total_xml_count, total_img_count)
+        else:
+            print "{}/{} TOTAL images labeled ({:.1%})".format(total_xml_count, total_img_count,
+                                                               total_xml_count / total_img_count)
+
+    def _read_bag(self, bagfile, segments):
+        """
+        Crawls through a single bag specified in the config YAML, placing
+        images into the Images/ directory of labelme.
+
+        Called me read_bags for each bag in YAML
+        """
+        bag = self._get_input_bag(bagfile)
+        _, _, first_time = bag.read_messages().next()
+        for segment in segments:
+            self._print("\tProccessing Segment '{}'", segment['name'])
+            # Put images in LABELMEDIR/Images/SEGMENTNAME/TOPIC, where TOPIC replaces / with @
+            paths = {}
+            for t in segment['topics']:
+                path = os.path.join(self.labelme_dir, 'Images', segment['name'].replace('/', '@'), t.replace('/', '@'))
+                if not os.path.exists(path):
+                    os.makedirs(path)
+                paths[t] = path
+            # Ensure start and stop are passed as None to read_messages if not defined
+            start = None
+            stop = None
+            interval = rospy.Duration(0)
+            if 'start' in segment:
+                start = first_time + rospy.Duration(segment['start'])
+            if 'stop' in segment:
+                stop = first_time + rospy.Duration(segment['stop'])
+            if 'freq' in segment:
+                interval = rospy.Duration(1.0 / segment['freq'])
+            next_time = start if start is not None else rospy.Time(0)
+            # Crawl through bag between start and stop time at freq
+            for topic, msg, time in bag.read_messages(topics=segment['topics'], start_time=start, end_time=stop):
+                if time >= next_time:
+                    # If enough time has elapsed, put an image in this segment's directory,
+                    # named by the frame's timestamp converted to a string: str(ros.Time(stamp))
+                    img = self.bridge.imgmsg_to_cv2(msg, desired_encoding="passthrough")
+                    filename = os.path.join(paths[topic], str(msg.header.stamp) + '.jpg')
+                    cv2.imwrite(filename, img)
+                    next_time = next_time + interval
+
+    def _print_bag_report(self, bagconfig):
+        """
+        Compares number of labeled XML files in LabelMe for a given
+        bag specified in YAML config to number of images in LabelMe for this
+        bag.
+
+        If verbose is enabled, prints info for each segment. Otherwise,
+        just returns total counts.
+
+        Called by print_report for each bag in config.
+        """
+        total_xml_count = 0
+        total_img_count = 0
+        for segment in bagconfig['segments']:
+            self._print("\t\tGenerating Report for segment '{}'", segment['name'])
+            xml_count = 0
+            img_count = 0
+            for t in segment['topics']:
+                xml_path = os.path.join(self.labelme_dir, 'Annotations', segment['name'].replace('/', '@'),
+                                        t.replace('/', '@'))
+                img_path = os.path.join(self.labelme_dir, 'Images', segment['name'].replace('/', '@'),
+                                        t.replace('/', '@'))
+                if os.path.isdir(xml_path):
+                    for xmlfile in os.listdir(xml_path):
+                        xml_count += 1
+                if os.path.isdir(img_path):
+                    for imgfile in os.listdir(img_path):
+                        img_count += 1
+            if img_count == 0:
                 self._print("\t\t\t{}/{} images labeled in this segment (0%)", xml_count, img_count)
-          else:
-                self._print("\t\t\t{}/{} images labeled in this segment ({:.1%})", xml_count, img_count, xml_count/img_count)
-          total_xml_count += xml_count
-          total_img_count += img_count
-      if total_img_count == 0:
-          self._print("\t\t{}/{} images labeled in this bag (0%)", total_xml_count, total_img_count)
-      else:
-          self._print("\t\t{}/{} images labeled in this bag ({:.1%})", total_xml_count, total_img_count, total_xml_count/total_img_count)
-      return total_xml_count, total_img_count
+            else:
+                self._print("\t\t\t{}/{} images labeled in this segment ({:.1%})", xml_count, img_count,
+                            xml_count / img_count)
+            total_xml_count += xml_count
+            total_img_count += img_count
+        if total_img_count == 0:
+            self._print("\t\t{}/{} images labeled in this bag (0%)", total_xml_count, total_img_count)
+        else:
+            self._print("\t\t{}/{} images labeled in this bag ({:.1%})", total_xml_count, total_img_count,
+                        total_xml_count / total_img_count)
+        return total_xml_count, total_img_count
 
-  def _parse_label_xml(self, filename):
-      """
-      Given an XML file containing annotation data in LabelMe format,
-      generates and returns a mil_msgs/LabeledObjects message
-      containing the same data.
-      """
-      msg = LabeledObjects()
-      e = xml.etree.ElementTree.parse(filename).getroot()
-      for obj in e.findall('object'):
-          obj_msg = LabeledObject()
-          obj_msg.name = obj.find('name').text
-          obj_msg.id = int(obj.find('id').text)
-          parent = obj.find('parts').find('ispartof').text
-          if parent != None:
-            obj_msg.parent_id = int(parent)
-          attributes = obj.find('attributes').text
-          if attributes != None:
-              obj_msg.attributes = attributes
-          polygon = obj.find('polygon')
-          for pt in polygon.findall('pt'):
-              x = int(pt.find('x').text)
-              y = int(pt.find('y').text)
-              obj_msg.polygon.append(Point(x, y, 0))
-          msg.objects.append(obj_msg)
-      return msg
+    def _parse_label_xml(self, filename):
+        """
+        Given an XML file containing annotation data in LabelMe format,
+        generates and returns a mil_msgs/LabeledObjects message
+        containing the same data.
+        """
+        msg = LabeledObjects()
+        e = xml.etree.ElementTree.parse(filename).getroot()
+        for obj in e.findall('object'):
+            obj_msg = LabeledObject()
+            obj_msg.name = obj.find('name').text
+            obj_msg.id = int(obj.find('id').text)
+            parent = obj.find('parts').find('ispartof').text
+            if parent is not None:
+                obj_msg.parent_id = int(parent)
+            attributes = obj.find('attributes').text
+            if attributes is not None:
+                obj_msg.attributes = attributes
+            polygon = obj.find('polygon')
+            for pt in polygon.findall('pt'):
+                x = int(pt.find('x').text)
+                y = int(pt.find('y').text)
+                obj_msg.polygon.append(Point(x, y, 0))
+            msg.objects.append(obj_msg)
+        return msg
 
-  def _get_labels_segment(self, segment, labels={}):
-      paths = {}
-      for t in segment['topics']:
-          if not labels.has_key(t):
-              labels[t] = {}
-          path = os.path.join(self.labelme_dir, 'Annotations', segment['name'].replace('/', '@'), t.replace('/', '@'))
-          if not os.path.isdir(path):
-              continue
-          for xmlfile in os.listdir(path):
-              stamp = xmlfile.split('.xml', 1)
-              assert len(stamp) == 2
-              labels[t][stamp[0]] = os.path.join(path, xmlfile)
-      return labels
+    def _get_labels_segment(self, segment, labels={}):
+        for t in segment['topics']:
+            if t not in labels:
+                labels[t] = {}
+            path = os.path.join(self.labelme_dir, 'Annotations', segment['name'].replace('/', '@'), t.replace('/', '@'))
+            if not os.path.isdir(path):
+                continue
+            for xmlfile in os.listdir(path):
+                stamp = xmlfile.split('.xml', 1)
+                assert len(stamp) == 2
+                labels[t][stamp[0]] = os.path.join(path, xmlfile)
+        return labels
 
-  def _get_labels(self, bag_config):
-      """
-      Given a config for a single bag, finds all XML files in LabelMe
-      containing data for the segments in this bag.
-      
-      returns a dictionary mapping ros.Time stamps to XML files.
-      Used by extract_labels to put labelme data back into bag.
-      """
-      labels = {}
-      for segment in bag_config['segments']:
-          for t in segment['topics']:
-              labels[t] = {}
-      for segment in bag_config['segments']:
-          labels = self._get_label_segment(segment, labels)
-      return labels
+    def _get_labels(self, bag_config):
+        """
+        Given a config for a single bag, finds all XML files in LabelMe
+        containing data for the segments in this bag.
 
-  def _get_bag_filename(self, filename, directory):
-      base = os.path.splitext(filename)[0]
-      assert len(base) != 0
-      return  os.path.join(directory, base + '.bag')
+        returns a dictionary mapping ros.Time stamps to XML files.
+        Used by extract_labels to put labelme data back into bag.
+        """
+        labels = {}
+        for segment in bag_config['segments']:
+            for t in segment['topics']:
+                labels[t] = {}
+        for segment in bag_config['segments']:
+            labels = self._get_label_segment(segment, labels)
+        return labels
 
-  def _get_input_bag(self, name):
-      filename = self._get_bag_filename(name, self.indir)
-      return rosbag.Bag(filename)
+    def _get_bag_filename(self, filename, directory):
+        base = os.path.splitext(filename)[0]
+        assert len(base) != 0
+        return os.path.join(directory, base + '.bag')
 
-  def _get_combined_output_bag(self, bag_config):
-      if bag_config.has_key('outfile'):
-          filename = self._get_bag_filename(bag_config['outfile'], self.outdir)
-          return rosbag.Bag(filename)
-      base = os.path.split(bag_config['file'])[1]
-      filename = self._get_bag_filename(base, self.outdir)
-      directory = os.path.split(filename)[0]
-      if not os.path.exists(directory):
-          os.makedirs(directory)
-      return rosbag.Bag(filename, mode='w')
+    def _get_input_bag(self, name):
+        filename = self._get_bag_filename(name, self.indir)
+        return rosbag.Bag(filename)
 
-  def _get_segment_output_bag(self, segment):
-      filename = segment['name']
-      if segment.has_key('outfile'):
-          filename = segment['outfile']
-      filename = self._get_bag_filename(filename, self.outdir)
-      directory = os.path.split(filename)[0]
-      if not os.path.exists(directory):
-          os.makedirs(directory)
-      return rosbag.Bag(filename, mode='w')
+    def _get_combined_output_bag(self, bag_config):
+        if 'outfile' in bag_config:
+            filename = self._get_bag_filename(bag_config['outfile'], self.outdir)
+            return rosbag.Bag(filename)
+        base = os.path.split(bag_config['file'])[1]
+        filename = self._get_bag_filename(base, self.outdir)
+        directory = os.path.split(filename)[0]
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+        return rosbag.Bag(filename, mode='w')
 
-  def _extract_labels_bag(self, bag_config):
-      bag = self._get_input_bag(bag_config['file'])
-      if bag_config['combined']:
-          label_files = self._get_labels(bag_config)
-          out = self._get_combined_output_bag(bag_config)
-          for topic, msg, t in bag.read_messages():
-            if msg._type == 'sensor_msgs/Image':
-                if topic in label_files:
-                    if str(msg.header.stamp) in label_files[topic]:
-                        labels = self._parse_label_xml(label_files[topic][str(msg.header.stamp)])
-                        labels.header = msg.header
-                        out.write(topic+'/labels', labels, t)
-            out.write(topic, msg, t)
-          out.flush()
-          out.close()
-      else:
-          _, _, first_time = bag.read_messages().next()
-          for segment in bag_config['segments']:
-              label_files = self._get_labels_segment(segment)
-              out = self._get_segment_output_bag(segment)
-              start = None
-              stop = None
-              if segment.has_key('start'):
-                  start = first_time + rospy.Duration(segment['start'])
-              if segment.has_key('stop'):
-                  stop = first_time + rospy.Duration(segment['stop'])
-              for topic, msg, t in bag.read_messages(start_time = start, end_time = stop):
-                  if msg._type == 'sensor_msgs/Image':
-                      if topic in label_files:
-                          if str(msg.header.stamp) in label_files[topic]:
-                              labels = self._parse_label_xml(label_files[topic][str(msg.header.stamp)])
-                              labels.header = msg.header
-                              out.write(topic+'/labels', labels, t)
-                  out.write(topic, msg, t)
-              out.flush()
-              out.close()
-      bag.close()
+    def _get_segment_output_bag(self, segment):
+        filename = segment['name']
+        if 'outfile' in segment:
+            filename = segment['outfile']
+        filename = self._get_bag_filename(filename, self.outdir)
+        directory = os.path.split(filename)[0]
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+        return rosbag.Bag(filename, mode='w')
+
+    def _extract_labels_bag(self, bag_config):
+        bag = self._get_input_bag(bag_config['file'])
+        if bag_config['combined']:
+            label_files = self._get_labels(bag_config)
+            out = self._get_combined_output_bag(bag_config)
+            for topic, msg, t in bag.read_messages():
+                if msg._type == 'sensor_msgs/Image':
+                    if topic in label_files:
+                        if str(msg.header.stamp) in label_files[topic]:
+                            labels = self._parse_label_xml(label_files[topic][str(msg.header.stamp)])
+                            labels.header = msg.header
+                            out.write(topic + '/labels', labels, t)
+                out.write(topic, msg, t)
+            out.flush()
+            out.close()
+        else:
+            _, _, first_time = bag.read_messages().next()
+            for segment in bag_config['segments']:
+                label_files = self._get_labels_segment(segment)
+                out = self._get_segment_output_bag(segment)
+                start = None
+                stop = None
+                if 'start' in segment:
+                    start = first_time + rospy.Duration(segment['start'])
+                if 'stop' in segment:
+                    stop = first_time + rospy.Duration(segment['stop'])
+                for topic, msg, t in bag.read_messages(start_time=start, end_time=stop):
+                    if msg._type == 'sensor_msgs/Image':
+                        if topic in label_files:
+                            if str(msg.header.stamp) in label_files[topic]:
+                                labels = self._parse_label_xml(label_files[topic][str(msg.header.stamp)])
+                                labels.header = msg.header
+                                out.write(topic + '/labels', labels, t)
+                    out.write(topic, msg, t)
+                out.flush()
+                out.close()
+        bag.close()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Generates rosbags based on LabelMe data and visa/versa')
     parser.add_argument('--config-file', '-c', dest='config', type=str, required=True,
-                        help='YAML file specifying what bags to read and extract images from. See example YAML for details')
-    parser.add_argument('--labelme-dir', '-d', dest='dir',type=str, required=True,
+                        help='YAML file specifying what bags to read and extract images from.\
+                              See example YAML for details')
+    parser.add_argument('--labelme-dir', '-d', dest='dir', type=str, required=True,
                         help='root directory of labelme instalation')
     parser.add_argument('--bag-dir', '-b', dest="bag_dir", type=str, default="",
                         help="directory to resolve relative paths specifed in YAML for input bags")
@@ -361,7 +366,8 @@ if __name__ == "__main__":
     parser.add_argument('--verbose', '-v', dest='verbose', action='store_true',
                         help='Print extra information about what the script is doing')
     args = parser.parse_args()
-    bag_to_labelme = BagToLabelMe(args.config, args.dir, verbose=args.verbose, indir=args.bag_dir, outdir=args.output_dir)
+    bag_to_labelme = BagToLabelMe(args.config, args.dir, verbose=args.verbose,
+                                  indir=args.bag_dir, outdir=args.output_dir)
     if args.do_dry_run:
         pass
     elif args.extract_labels:

--- a/utils/mil_tools/mil_ros_tools/label_me_bag.py
+++ b/utils/mil_tools/mil_ros_tools/label_me_bag.py
@@ -87,7 +87,7 @@ class BagToLabelMe():
               verify_attr(segment, 'topics', 'segment')
               # Ensure topics is still a list
               if type(segment['topics']) == str:
-                  self.config['bags'][i]['segments'][j]['topics'] = [self.config['bags'][i]['segments'][j]['topics']]
+                  self.config['bags'][i]['segments'][j]['topics'] = [segment]
               verify_attr(segment, 'name', 'segment')
               self._print("\t\tFound segment '{}' of topics '{}' from {} to {} every {}",
                           segment['name'], segment['topics'],

--- a/utils/mil_tools/mil_ros_tools/label_me_bag.py
+++ b/utils/mil_tools/mil_ros_tools/label_me_bag.py
@@ -17,6 +17,7 @@ back into a bag.
 
 """
 
+from __future__ import division
 import argparse
 import yaml
 import xml.etree.ElementTree
@@ -38,7 +39,7 @@ class BagToLabelMe():
   
   TODO: improve verbosity, disable print statements with toggle
   """
-  def __init__(self, config, labelme_dir, verbose=False):
+  def __init__(self, config, labelme_dir, verbose=False, indir='', outdir=''):
       """
       Generates class that can be used to insert or extract images to/from LabelMe
       
@@ -54,6 +55,8 @@ class BagToLabelMe():
       self._verify_yaml()
       self.bridge = CvBridge()
       self.labelme_dir = labelme_dir
+      self.indir = indir
+      self.outdir = outdir
 
   def _print(self, string,*args):
       if self.verbose:
@@ -72,21 +75,22 @@ class BagToLabelMe():
               raise Exception("{} does not have required attribute {} in config".format(objname, attr))
       verify_attr(self.config, 'bags', 'Config')
       self._print('Pulling segments from {} bag(s):', len(self.config['bags']))
-      for bag in self.config['bags']:
+      for i, bag in enumerate(self.config['bags']):
           verify_attr(bag, 'file', 'Bag')
-          verify_attr(bag, 'labeled_file', 'Bag')
           if not 'file' in bag:
               raise Exception("Bag does not contain 'file' attribute {}".format(bag))
           verify_attr(bag, 'segments', bag['file'])
+          if not bag.has_key('combined'):
+              self.config['bags'][i]['combined'] = False
           self._print('\tFound {} segments for {}:', len(bag['segments']), bag['file'])
-          for segment in bag['segments']:
-              verify_attr(segment, 'start', 'segment', throw=False)
-              verify_attr(segment, 'stop', 'segment', throw=False)
-              verify_attr(segment, 'freq', 'segment', throw=False)
-              verify_attr(segment, 'topic', 'segment')
+          for j, segment in enumerate(bag['segments']):
+              verify_attr(segment, 'topics', 'segment')
+              # Ensure topics is still a list
+              if type(segment['topics']) == str:
+                  self.config['bags'][i]['segments'][j]['topics'] = [self.config['bags'][i]['segments'][j]['topics']]
               verify_attr(segment, 'name', 'segment')
-              self._print("\t\tFound segment '{}' from topic '{}' from {} to {} every {}",
-                          segment['name'], segment['topic'],
+              self._print("\t\tFound segment '{}' of topics '{}' from {} to {} every {}",
+                          segment['name'], segment['topics'],
                           segment['start'] if segment.has_key('start') else 'start',
                           segment['stop'] if segment.has_key('stop') else 'stop',
                           str(segment['freq']) + ' seconds' if segment.has_key('freq') else 'frame')
@@ -113,15 +117,7 @@ class BagToLabelMe():
       self._print("Extracting labels for all bags in config")
       for bag in self.config['bags']:
           self._print("\tExtracting LabelMe annotations for {}".format(bag['file']))
-          # TODO: give output bag a default name like INFILE_labeled.bag
-          if not bag.has_key('labeled_file'):
-              split = os.path.split(bag['file'])
-              filename = split[1].rsplit('.bag', 1)[0]
-              outfile = os.path.join(split[0], filename, '.bag')
-              self._extract_labels_bag(bag, outfile)
-          else:
-              outfile = bag['labeled_file']
-              self._extract_labels_bag(bag, outfile)
+          self._extract_labels_bag(bag)
 
   def print_report(self):
       """
@@ -151,14 +147,17 @@ class BagToLabelMe():
       
       Called me read_bags for each bag in YAML
       """
-      bag = rosbag.Bag(bagfile)
+      bag = self._get_input_bag(bagfile)
       _, _, first_time = bag.read_messages().next()
       for segment in segments:
           self._print("\tProccessing Segment '{}'",segment['name'])
           # Put images in LABELMEDIR/Images/SEGMENTNAME/TOPIC, where TOPIC replaces / with @
-          path = os.path.join(self.labelme_dir, 'Images', segment['name'], segment['topic'].replace('/', '@'))
-          if not os.path.exists(path):
-              os.makedirs(path)
+          paths = {}
+          for t in segment['topics']:
+              path = os.path.join(self.labelme_dir, 'Images', segment['name'].replace('/', '@'), t.replace('/', '@'))
+              if not os.path.exists(path):
+                  os.makedirs(path)
+              paths[t] = path
           # Ensure start and stop are passed as None to read_messages if not defined
           start = None
           stop = None
@@ -171,12 +170,12 @@ class BagToLabelMe():
               interval = rospy.Duration(1.0 / segment['freq'])
           next_time = start if start is not None else rospy.Time(0)
           # Crawl through bag between start and stop time at freq
-          for topic, msg, time in bag.read_messages(topics=[segment['topic']], start_time = start, end_time = stop):
+          for topic, msg, time in bag.read_messages(topics=segment['topics'], start_time = start, end_time = stop):
               if time >= next_time:
                   # If enough time has elapsed, put an image in this segment's directory,
                   # named by the frame's timestamp converted to a string: str(ros.Time(stamp))
                   img = self.bridge.imgmsg_to_cv2(msg, desired_encoding="passthrough")
-                  filename = os.path.join(path, str(msg.header.stamp) + '.jpg')
+                  filename = os.path.join(paths[topic], str(msg.header.stamp) + '.jpg')
                   cv2.imwrite(filename, img)
                   next_time = next_time + interval
       
@@ -195,18 +194,17 @@ class BagToLabelMe():
       total_img_count = 0
       for segment in bagconfig['segments']:
           self._print("\t\tGenerating Report for segment '{}'",segment['name'])
-          xml_path = os.path.join(self.labelme_dir, 'Annotations', segment['name'], segment['topic'].replace('/', '@'))
-          img_path = os.path.join(self.labelme_dir, 'Images', segment['name'], segment['topic'].replace('/', '@'))
           xml_count = 0
           img_count = 0
-          if os.path.isdir(xml_path):
-              for xmlfile in os.listdir(xml_path):
-                  xml_count += 1
-          if os.path.isdir(img_path):
-              for imgfile in os.listdir(img_path):
-                  img_count += 1
-          else:
-              raise Exception("Directory {} not found. Have you run once to generate images yet?".format(img_path))
+          for t in segment['topics']:
+              xml_path = os.path.join(self.labelme_dir, 'Annotations', segment['name'].replace('/', '@'), t.replace('/', '@'))
+              img_path = os.path.join(self.labelme_dir, 'Images', segment['name'].replace('/', '@'), t.replace('/', '@'))
+              if os.path.isdir(xml_path):
+                  for xmlfile in os.listdir(xml_path):
+                      xml_count += 1
+              if os.path.isdir(img_path):
+                  for imgfile in os.listdir(img_path):
+                      img_count += 1
           if img_count == 0:
                 self._print("\t\t\t{}/{} images labeled in this segment (0%)", xml_count, img_count)
           else:
@@ -245,6 +243,20 @@ class BagToLabelMe():
           msg.objects.append(obj_msg)
       return msg
 
+  def _get_labels_segment(self, segment, labels={}):
+      paths = {}
+      for t in segment['topics']:
+          if not labels.has_key(t):
+              labels[t] = {}
+          path = os.path.join(self.labelme_dir, 'Annotations', segment['name'].replace('/', '@'), t.replace('/', '@'))
+          if not os.path.isdir(path):
+              continue
+          for xmlfile in os.listdir(path):
+              stamp = xmlfile.split('.xml', 1)
+              assert len(stamp) == 2
+              labels[t][stamp[0]] = os.path.join(path, xmlfile)
+      return labels
+
   def _get_labels(self, bag_config):
       """
       Given a config for a single bag, finds all XML files in LabelMe
@@ -255,32 +267,76 @@ class BagToLabelMe():
       """
       labels = {}
       for segment in bag_config['segments']:
-          labels[segment['topic']] = {}
+          for t in segment['topics']:
+              labels[t] = {}
       for segment in bag_config['segments']:
-          path = os.path.join(self.labelme_dir, 'Annotations', segment['name'], segment['topic'].replace('/', '@'))
-          self._print("\t\tExtracting LabelMe annotations from {}", path)
-          if not os.path.isdir(path):
-              continue
-          for xmlfile in os.listdir(path):
-              stamp = xmlfile.split('.xml', 1)
-              assert len(stamp) == 2
-              labels[segment['topic']][stamp[0]] = os.path.join(path, xmlfile)
+          labels = self._get_label_segment(segment, labels)
       return labels
 
-  def _extract_labels_bag(self, bag_config, out):
-      label_files = self._get_labels(bag_config)
-      bag = rosbag.Bag(bag_config['file'])
-      out = rosbag.Bag(out, mode='w')
-      _, _, first_time = bag.read_messages().next()
-      for topic, msg, t in bag.read_messages():
-        if msg._type == 'sensor_msgs/Image':
-            if topic in label_files:
-                if str(msg.header.stamp) in label_files[topic]:
-                    labels = self._parse_label_xml(label_files[topic][str(msg.header.stamp)])
-                    labels.header = msg.header
-                    out.write(topic+'/labels', labels, t)
-        out.write(topic, msg, t)
-      out.flush()
+  def _get_bag_filename(self, filename, directory):
+      base = os.path.splitext(filename)[0]
+      assert len(base) != 0
+      return  os.path.join(directory, base + '.bag')
+
+  def _get_input_bag(self, name):
+      filename = self._get_bag_filename(name, self.indir)
+      return rosbag.Bag(filename)
+
+  def _get_combined_output_bag(self, bag_config):
+      if bag_config.has_key('outfile'):
+          filename = self._get_bag_filename(bag_config['outfile'], self.outdir)
+          return rosbag.Bag(filename)
+      base = os.path.split(bag_config['file'])[1]
+      filename = self._get_bag_filename(base, self.outdir)
+      directory = os.path.split(filename)[0]
+      if not os.path.exists(directory):
+          os.makedirs(directory)
+      return rosbag.Bag(filename, mode='w')
+
+  def _get_segment_output_bag(self, segment):
+      filename = segment['name']
+      if segment.has_key('outfile'):
+          filename = segment['outfile']
+      filename = self._get_bag_filename(filename, self.outdir)
+      directory = os.path.split(filename)[0]
+      if not os.path.exists(directory):
+          os.makedirs(directory)
+      return rosbag.Bag(filename, mode='w')
+
+  def _extract_labels_bag(self, bag_config):
+      bag = self._get_input_bag(bag_config['file'])
+      if bag_config['combined']:
+          label_files = self._get_labels(bag_config)
+          out = self._get_combined_output_bag(bag_config)
+          for topic, msg, t in bag.read_messages():
+            if msg._type == 'sensor_msgs/Image':
+                if topic in label_files:
+                    if str(msg.header.stamp) in label_files[topic]:
+                        labels = self._parse_label_xml(label_files[topic][str(msg.header.stamp)])
+                        labels.header = msg.header
+                        out.write(topic+'/labels', labels, t)
+            out.write(topic, msg, t)
+          out.flush()
+      else:
+          _, _, first_time = bag.read_messages().next()
+          for segment in bag_config['segments']:
+              label_files = self._get_labels_segment(segment)
+              out = self._get_segment_output_bag(segment)
+              start = None
+              stop = None
+              if segment.has_key('start'):
+                  start = first_time + rospy.Duration(segment['start'])
+              if segment.has_key('stop'):
+                  stop = first_time + rospy.Duration(segment['stop'])
+              for topic, msg, t in bag.read_messages(start_time = start, end_time = stop):
+                  if msg._type == 'sensor_msgs/Image':
+                      if topic in label_files:
+                          if str(msg.header.stamp) in label_files[topic]:
+                              labels = self._parse_label_xml(label_files[topic][str(msg.header.stamp)])
+                              labels.header = msg.header
+                              out.write(topic+'/labels', labels, t)
+                  out.write(topic, msg, t)
+              out.flush()
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Generates rosbags based on LabelMe data and visa/versa')
@@ -288,6 +344,10 @@ if __name__ == "__main__":
                         help='YAML file specifying what bags to read and extract images from. See example YAML for details')
     parser.add_argument('--labelme-dir', '-d', dest='dir',type=str, required=True,
                         help='root directory of labelme instalation')
+    parser.add_argument('--bag-dir', '-b', dest="bag_dir", type=str, default="",
+                        help="directory to resolve relative paths specifed in YAML for input bags")
+    parser.add_argument('--output-dir', '-o', dest="output_dir", type=str, default="",
+                        help="directory to resolve relative paths specified in YAML for output (labeled) bags")
     parser.add_argument('--inject-annotations', '-i', dest='extract_labels', action='store_true',
                         help='Instead of putting bag images into LabelMe, read annotations from labelme,\
                               inserting them into a new bag as specified in config')
@@ -298,7 +358,7 @@ if __name__ == "__main__":
     parser.add_argument('--verbose', '-v', dest='verbose', action='store_true',
                         help='Print extra information about what the script is doing')
     args = parser.parse_args()
-    bag_to_labelme = BagToLabelMe(args.config, args.dir, verbose = args.verbose)
+    bag_to_labelme = BagToLabelMe(args.config, args.dir, verbose=args.verbose, indir=args.bag_dir, outdir=args.output_dir)
     if args.do_dry_run:
         pass
     elif args.extract_labels:

--- a/utils/mil_tools/mil_ros_tools/label_me_bag_example.yaml
+++ b/utils/mil_tools/mil_ros_tools/label_me_bag_example.yaml
@@ -1,13 +1,15 @@
 bags:                                       # List of bags to generate images for labeling from
   - file: orange_pipes.bag                  # File to pull images from
-    labeled_file: orange_pipes_labeled.bag  # Output file for original data + label topics
+    combined: False                         # If true all labeled segments go into one bag,
+                                            # otherwise each segment produces its own bag
     segments:                               # List of named segments in bag to get images from
       - name: path_marker_1                 # Name of segment to appear in LabelMe
         start: 1.0                          # Duration in seconds to start getting images, optional
         stop: 2.0                           # Duration in seconds to stop getting images, optional
-        topic: /down/left/image_raw         # Topic to pull images from
+        topics: /down/left/image_raw        # Topic to pull images from, can be multiple (ex: stereo)
                                             # Note missing freq, will pull each frame in this time period
       - name: path_marker_2
-        topic: /down/left/image_raw
+        topics: [/front/left/image_rect_color, /front/right/image_rect_color] #List of two topics
         freq: 1.0                           # Frequency to pull images from bag in Hz, optional
+        outfile: pool_low_lighting.bag      # Optional explicit name of bag, defaults to <segment name>.bag
                                             # Note missing start and stop, will pull from entire bag

--- a/utils/mil_tools/mil_ros_tools/msg_helpers.py
+++ b/utils/mil_tools/mil_ros_tools/msg_helpers.py
@@ -9,7 +9,7 @@ import rospy
 def rosmsg_to_numpy(rosmsg, keys=None):
     '''Convert an arbitrary ROS msg to a numpy array
     With no additional arguments, it will by default handle:
-        Point2D, Point3D, Vector3D, and quaternions
+        Point2D, Point3D, Vector3D, Quaternion and any lists of these (like Polygon)
 
     Ex:
         quat = Quaternion(1.0, 0.0, 0.0, 0.0)
@@ -31,6 +31,14 @@ def rosmsg_to_numpy(rosmsg, keys=None):
         - This function is designed to handle the most common use cases (vectors, points and quaternions)
             without requiring any additional arguments.
     '''
+
+    # Recurse for lists like geometry_msgs/Polygon, Pointclou
+    if type(rosmsg) == list:
+        output_array = []
+        for item in rosmsg:
+            output_array.append(rosmsg_to_numpy(item, keys=keys))
+        return np.array(output_array).astype(np.float32)
+
     if keys is None:
         keys = ['x', 'y', 'z', 'w']
         output_array = []
@@ -142,6 +150,11 @@ def numpy_quat_pair_to_pose(np_translation, np_quaternion):
     position = numpy_to_point(np_translation)
     return geometry_msgs.Pose(position=position, orientation=orientation)
 
+def numpy_to_polygon(polygon):
+    points = []
+    for point in polygon:
+        points.append(numpy_to_point(point))
+    return geometry_msgs.Polygon(points=points)
 
 def make_header(frame='/body', stamp=None):
     if stamp is None:


### PR DESCRIPTION
* Improve label me bag interface. Each segment can now contain multiple image topics (ex: stereo) and will produce its own bag (rather than one bag for every segment produced from the same input bag)
* fix bag has a few new options, including specifying timestamps to crop a bag and a list of topics to either include or ignore in the output bag

I tested the labelme script with the bags in the path marker and it worked well. I gave it a YAML, ran the script, and the images showed up on my LabelMe server. After I finished labeling, I ran it with the ```-i``` flag and it produced a bag for each segment containing the original data and the labels. 