### PR TITLE
FORMAT: Undo automatic formatting on files modified by #17

### DIFF
--- a/drivers/mil_passive_sonar/mil_passive_sonar/sonar_driver.py
+++ b/drivers/mil_passive_sonar/mil_passive_sonar/sonar_driver.py
@@ -28,7 +28,7 @@ matplotlib.use("WX")
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 fig = plt.figure(0)
-fig2 = plt.figure(1)
+fig2 =plt.figure(1)
 plt.ion()
 plt.show()
 
@@ -43,7 +43,6 @@ class Sub8Sonar():
     TODO: Add a function to try and reconnect to the serial port if we lose connection.
     TODO: Express pulse location in map frame
     '''
-
     def __init__(self, method, c, hydrophone_locations, port, baud=19200):
         rospy.init_node("sonar")
 
@@ -61,7 +60,7 @@ class Sub8Sonar():
 
         try:
             self.ser = serial.Serial(port=port, baudrate=baud, timeout=None)
-            self.ser.flushInput()
+            self.ser.flushInput()        
         except Exception, e:
             print "\x1b[31mSonar serial  connection error:\n\t", e, "\x1b[0m"
             return None
@@ -69,17 +68,14 @@ class Sub8Sonar():
         self.c = c
         self.hydrophone_locations = []
         for key in hydrophone_locations:
-            sensor_location = np.array(
-                [hydrophone_locations[key]['x'], hydrophone_locations[key]['y'], hydrophone_locations[key]['z']])
+            sensor_location = np.array([hydrophone_locations[key]['x'], hydrophone_locations[key]['y'], hydrophone_locations[key]['z']])
             self.hydrophone_locations += [sensor_location]
-        self.multilaterator = Multilaterator(
-            hydrophone_locations, self.c, method)  # speed of sound in m/s
+        self.multilaterator = Multilaterator(hydrophone_locations, self.c, method) # speed of sound in m/s
         self.est_signal_freq_kHz = 0
         self._freq_sum = 0
         self._freq_samples = 0
 
-        rospy.Service('~/sonar/get_pinger_pulse', Sonar,
-                      self.get_pulse_from_raw_data)
+        rospy.Service('~/sonar/get_pinger_pulse', Sonar, self.get_pulse_from_raw_data)
         print "\x1b[32mSub8 sonar driver initialized\x1b[0m"
         rospy.spin()
 
@@ -107,12 +103,11 @@ class Sub8Sonar():
         response = self.ser.read(19)
         # rospy.loginfo("Received: %s" % response) #uncomment for debugging
         if self.check_CRC(response):
-            delete_last_lines(0)  # Heard response!
+            delete_last_lines(0) # Heard response!
             # The checksum matches the data so split the response into each piece of data.
-            # For info on what these letters mean:
-            # https://docs.python.org/2/library/struct.html#format-characters
+            # For info on what these letters mean: https://docs.python.org/2/library/struct.html#format-characters
             data = struct.unpack('>BffffH', response)
-            timestamps = [data[4], data[1], data[2], data[3]]
+            timestamps = [data[4], data[1], data[2], data[3] ]
             print "timestamps:", timestamps
             return timestamps
         else:
@@ -149,8 +144,7 @@ class Sub8Sonar():
         waves_recorded = 3
         samples_per_wave = 17.24
         upsample_scale = 3
-        exp_recording_size = np.floor(
-            samples_per_wave) * waves_recorded * upsample_scale - 1
+        exp_recording_size = np.floor(samples_per_wave) * waves_recorded * upsample_scale - 1
         raw_signals = np.zeros([4, exp_recording_size], dtype=float)
 
         try:
@@ -162,17 +156,15 @@ class Sub8Sonar():
                 start_bit = self.ser.read(1)
                 timeout += 1
                 if timeout > 600:
-                    raise BufferError(
-                        "Timeout: failed to read a start bit from sonar board")
+                    raise BufferError("Timeout: failed to read a start bit from sonar board")
             for elem in np.nditer(raw_signals, op_flags=['readwrite']):
-                # ... is idx to current elem
-                elem[...] = float(self.ser.read(5)) - signal_bias
+                elem[...] = float(self.ser.read(5)) - signal_bias  # ... is idx to current elem
         except BufferError as e:
             print e
 
         non_zero_end_idx = 57
         up_factor = 8
-        sampling_freq = 430E3 * 0.8  # Hz
+        sampling_freq = 430E3 * 0.8 # Hz
         samp_period = 1E6 / sampling_freq  # microseconds
         upsamp_step = samp_period / up_factor
 
@@ -180,14 +172,13 @@ class Sub8Sonar():
         raw_signals = raw_signals[:, 0:non_zero_end_idx]
 
         # upsample the signals for successful cross-correlation
-        upsampled_signals = [resample(x, up_factor * len(x))
-                             for x in raw_signals]
+        upsampled_signals = [resample(x, up_factor*len(x)) for x in raw_signals]
 
         # scale waves so they all have the same variance
         equalized_signals = [x / np.std(x) for x in upsampled_signals]
         raw_signals = [x / np.std(x) for x in raw_signals]
         w0_upsamp, w1_upsamp, w2_upsamp, w3_upsamp = equalized_signals
-        t_up = np.arange(0, non_zero_end_idx * samp_period, upsamp_step)
+        t_up = np.arange(0, non_zero_end_idx*samp_period, upsamp_step)
 
         zero_crossings = np.where(np.diff(np.sign(w0_upsamp)))[0]
         num_crossings = len(zero_crossings)
@@ -195,13 +186,12 @@ class Sub8Sonar():
             zero_crossings = zero_crossings[1:]
             num_crossings -= 1
         waves_between_first_and_last_crossing = (num_crossings - 1) / 2
-        time_between_first_and_last_crossing = t_up[zero_crossings[-1]
-                                                    ] - t_up[zero_crossings[0]]
-        curr_signal_freq_kHz = 1E3 * waves_between_first_and_last_crossing / \
-            time_between_first_and_last_crossing  # kHz
+        time_between_first_and_last_crossing = t_up[zero_crossings[-1]] - t_up[zero_crossings[0]]
+        curr_signal_freq_kHz = 1E3 * waves_between_first_and_last_crossing / time_between_first_and_last_crossing # kHz
         self._freq_sum += curr_signal_freq_kHz
         self._freq_samples += 1
         self.est_signal_freq_kHz = self._freq_sum / self._freq_samples
+
 
         # frequencies, spectrum = periodogram(w0_upsamp, sampling_freq * up_factor)
         # signal_freq = frequencies[np.argmax(spectrum)]  # Hz
@@ -220,25 +210,22 @@ class Sub8Sonar():
         waves_non_ref = 2.5
         samples_per_wave = signal_period / samp_period
         ref_upsamples = int(round(waves_ref * samples_per_wave * up_factor))
-        nonref_upsamples = int(
-            np.ceil(waves_non_ref * samples_per_wave * up_factor))
+        nonref_upsamples = int(np.ceil(waves_non_ref * samples_per_wave * up_factor))
 
         ref_start_idx = None
         if (len(w0_upsamp) % 2 == ref_upsamples % 2):
-            ref_start_idx = int(
-                round((upsamples_recorded / 2) - (ref_upsamples / 2)))
+            ref_start_idx = int(round((upsamples_recorded / 2) - (ref_upsamples / 2)))
         else:
-            ref_start_idx = int(
-                np.ceil((upsamples_recorded / 2) - (ref_upsamples / 2)))
+            ref_start_idx = int(np.ceil((upsamples_recorded / 2) - (ref_upsamples / 2)))
         ref_end_idx = ref_start_idx + ref_upsamples - 1
         nonref_end_idx = ref_start_idx + nonref_upsamples - 1
 
-        w0_select = w0_upsamp[ref_start_idx: ref_end_idx + 1]
-        w1_select = w1_upsamp[ref_start_idx: nonref_end_idx + 1]
-        w2_select = w2_upsamp[ref_start_idx: nonref_end_idx + 1]
-        w3_select = w3_upsamp[ref_start_idx: nonref_end_idx + 1]
-        t_ref_select = t_up[ref_start_idx: ref_end_idx + 1]
-        t_nonref_select = t_up[ref_start_idx: nonref_end_idx + 1]
+        w0_select = w0_upsamp[ref_start_idx : ref_end_idx + 1]
+        w1_select = w1_upsamp[ref_start_idx : nonref_end_idx + 1]
+        w2_select = w2_upsamp[ref_start_idx : nonref_end_idx + 1]
+        w3_select = w3_upsamp[ref_start_idx : nonref_end_idx + 1]
+        t_ref_select = t_up[ref_start_idx : ref_end_idx + 1]
+        t_nonref_select = t_up[ref_start_idx : nonref_end_idx + 1]
 
         cc1 = np.correlate(w0_select, w1_select, mode='full')
         cc2 = np.correlate(w0_select, w2_select, mode='full')
@@ -256,9 +243,8 @@ class Sub8Sonar():
         ax5 = fig.add_subplot(515)
         axarr = [ax1, ax2, ax3, ax4, ax5]
 
-        axarr[0].plot(t_up, w1_upsamp, 'r', t_up, w2_upsamp, 'g',
-                      t_up, w3_upsamp, 'b', t_up, w0_upsamp, 'k')
-        axarr[0].axis([0, 60 * samp_period, -3, 3])
+        axarr[0].plot(t_up,w1_upsamp,'r',t_up,w2_upsamp,'g',t_up,w3_upsamp,'b',t_up,w0_upsamp,'k')
+        axarr[0].axis([0,60*samp_period,-3,3])
         axarr[0].set_title('Signals')
 
         axarr[1].plot(t_nonref_select, w1_select, 'r',
@@ -277,7 +263,7 @@ class Sub8Sonar():
         plt.draw()
         plt.pause(0.1)
 
-        return [0, 0, 0, 0]  # DBG
+        return [0,0,0,0] #DBG
 
     def max_delta_t(hydrophone_idx_a, hydrophone_idx_b):
         a = self.hydrophone_locations[hydrophone_idx_a]
@@ -306,14 +292,12 @@ class Sub8Sonar():
         else:
             return False
 
-
 def delete_last_lines(n=1):
     CURSOR_UP_ONE = '\x1b[1A'
     ERASE_LINE = '\x1b[2K'
     for _ in range(n):
         sys.stdout.write(CURSOR_UP_ONE)
         sys.stdout.write(ERASE_LINE)
-
 
 if __name__ == "__main__":
     d = Sub8Sonar('LS', 1.484, rospy.get_param('~/sonar_driver/hydrophones'),

--- a/drivers/mil_passive_sonar/multilateration/multilateration.py
+++ b/drivers/mil_passive_sonar/multilateration/multilateration.py
@@ -18,14 +18,12 @@ class Multilaterator(object):
     Note:
         hydrophone locations should be the dict returned by rospy.get_param('~/<node name>/hydrophones
     '''
-
     def __init__(self, hydrophone_locations, c, method):  # speed in millimeters/microsecond
         self.hydrophone_locations = []
         for key in hydrophone_locations:
-            sensor_location = np.array(
-                [hydrophone_locations[key]['x'], hydrophone_locations[key]['y'], hydrophone_locations[key]['z']])
+            sensor_location = np.array([hydrophone_locations[key]['x'], hydrophone_locations[key]['y'], hydrophone_locations[key]['z']])
             self.hydrophone_locations += [sensor_location]
-        self.pairs = list(combinations(range(len(hydrophone_locations)), 2))
+        self.pairs = list(combinations(range(len(hydrophone_locations)),2))
         self.c = c
         self.method = method
         print "\x1b[32mSpeed of Sound (c):", self.c, "millimeter/microsecond\x1b[0m"
@@ -59,53 +57,48 @@ class Multilaterator(object):
             response = SonarResponse()
             response.x, response.y, response.z = (0, 0, 0)
 
+
     def estimate_pos_bancroft(self, reception_times):
         N = len(reception_times)
         assert N >= 4
-
-        def L(a, b): return a[0] * b[0] + a[1] * \
-            b[1] + a[2] * b[2] - a[3] * b[3]
-
+        
+        L = lambda a, b: a[0]*b[0] + a[1]*b[1] + a[2]*b[2] - a[3]*b[3]
+        
         def get_B(delta):
             B = np.zeros((N, 4))
             for i in xrange(N):
-                B[i] = np.concatenate(
-                    [self.hydrophone_locations[i] / (self.c), [-reception_times[i]]]) + delta
+                B[i] = np.concatenate([self.hydrophone_locations[i]/(self.c), [-reception_times[i]]]) + delta
             return B
-
-        delta = min([.1 * np.random.randn(4) for i in xrange(10)],
-                    key=lambda delta: np.linalg.cond(get_B(delta)))
-        # delta = np.zeros(4) # gives very good heading for noisy timestamps,
-        # although range is completely unreliable
+        
+        delta = min([.1*np.random.randn(4) for i in xrange(10)], key=lambda delta: np.linalg.cond(get_B(delta)))
+        # delta = np.zeros(4) # gives very good heading for noisy timestamps, although range is completely unreliable
 
         B = get_B(delta)
         a = np.array([0.5 * L(B[i], B[i]) for i in xrange(N)])
         e = np.ones(N)
-
+        
         Bpe = np.linalg.lstsq(B, e)[0]
         Bpa = np.linalg.lstsq(B, a)[0]
-
+        
         Lambdas = quadratic(
             L(Bpe, Bpe),
-            2 * (L(Bpa, Bpe) - 1),
+            2*(L(Bpa, Bpe) - 1),
             L(Bpa, Bpa))
-        if not Lambdas:
+        if not Lambdas: 
             return [0, 0, 0]
-
+        
         res = []
         for Lambda in Lambdas:
             u = Bpa + Lambda * Bpe
             position = u[:3] - delta[:3]
             time = u[3] + delta[3]
-            if any(reception_times[i] < time for i in xrange(N)):
-                continue
-            res.append(position * self.c)
+            if any(reception_times[i] < time for i in xrange(N)): continue
+            res.append(position*self.c)
         if len(res) == 1:
             source = res[0]
         elif len(res) == 2:
-            # Assume that the source is below us
-            source = [x for x in res if x[2] < 0]
-            if not source:
+            source = [x for x in res if x[2] < 0]   # Assume that the source is below us
+            if not source: 
                 source = res[0]
             else:
                 source = source[0]
@@ -118,11 +111,10 @@ class Multilaterator(object):
         Returns a ros message with the location and time of emission of a pinger pulse.
         '''
         self.timestamps = timestamps
-        init_guess = np.random.normal(0, 100, 3)
+        init_guess = np.random.normal(0,100,3)
         opt = {'disp': 0}
         opt_method = 'Powell'
-        result = optimize.minimize(
-            self.cost_LS, init_guess, method=opt_method, options=opt, tol=1e-15)
+        result = optimize.minimize(self.cost_LS, init_guess, method=opt_method, options=opt, tol=1e-15)
         if(result.success):
             source = [result.x[0], result.x[1], result.x[2]]
         else:
@@ -143,8 +135,7 @@ class Multilaterator(object):
         for pair in self.pairs:
             h0 = self.hydrophone_locations[pair[0]]
             h1 = self.hydrophone_locations[pair[1]]
-            residual = la.norm(x - h0) - la.norm(x - h1) - \
-                c * (t[pair[0]] - t[pair[1]])
+            residual = la.norm(x-h0) - la.norm(x-h1) - c*(t[pair[0]] - t[pair[1]])
             cost += residual**2
         return cost
 
@@ -179,31 +170,25 @@ class ReceiverArraySim(object):
             time   - microseconds
             length - millimeters
     """
-
     def __init__(self, hydrophone_locations, wave_propagation_speed_mps):
         self.c = wave_propagation_speed_mps
         self.hydrophone_locations = np.array([0, 0, 0])
         for key in hydrophone_locations:
-            sensor_location = np.array(
-                [hydrophone_locations[key]['x'], hydrophone_locations[key]['y'], hydrophone_locations[key]['z']])
-            self.hydrophone_locations = np.vstack(
-                (self.hydrophone_locations, sensor_location))
+            sensor_location = np.array([hydrophone_locations[key]['x'], hydrophone_locations[key]['y'], hydrophone_locations[key]['z']])
+            self.hydrophone_locations = np.vstack((self.hydrophone_locations, sensor_location))
         self.hydrophone_locations = self.hydrophone_locations[1:]
 
     def listen(self, pulse):
         timestamps = []
         for idx in range(4):
-            src_range = np.sqrt(
-                sum(np.square(pulse.position() - self.hydrophone_locations[idx])))
+            src_range = np.sqrt(sum(np.square(pulse.position() - self.hydrophone_locations[idx])))
             timestamps += [pulse.t + src_range / self.c]
         return np.array(timestamps)
-
 
 class Pulse(object):
     """
     Represents an omnidirectional wave or impulse emmited from a point source
     """
-
     def __init__(self, x, y, z, t):
         self.x = x
         self.y = y
@@ -219,9 +204,9 @@ class Pulse(object):
 
 
 def quadratic(a, b, c):
-    discriminant = b * b - 4 * a * c
+    discriminant = b*b - 4*a*c
     if discriminant >= 0:
-        first_times_a = (-b + math.copysign(math.sqrt(discriminant), -b)) / 2
-        return [first_times_a / a, c / first_times_a]
+        first_times_a = (-b+math.copysign(math.sqrt(discriminant), -b))/2
+        return [first_times_a/a, c/first_times_a]
     else:
         return []

--- a/drivers/mil_passive_sonar/nodes/pinger_finder.py
+++ b/drivers/mil_passive_sonar/nodes/pinger_finder.py
@@ -11,7 +11,6 @@ from visualization_msgs.msg import Marker
 from std_srvs.srv import SetBool, SetBoolResponse
 import navigator_tools
 
-
 class PingerFinder(object):
     """
     This class will find the position of a pinger at a given frequency. For it 
@@ -39,23 +38,18 @@ class PingerFinder(object):
         self.freq_tol = 1E3
         self.min_amp = 200  # if too many outliers, increase this
         self.max_observations = 200
-        self.line_array = np.empty((0, 4), float)
+        self.line_array =np.empty((0, 4), float)
         self.observation_amplitudes = np.empty((0, 0), float)
         self.pinger_position = Point(0, 0, 0)
         self.heading_pseudorange = 10
         self.debug_arrow_id = 0
         self.debug_arrow_lifetime = rospy.Duration(10, 0)
         self.listen = False
-        self.ping_sub = rospy.Subscriber(
-            "/hydrophones/processed", ProcessedPing, callback=self.ping_cb)
-        self.marker_pub = rospy.Publisher(
-            "/visualization_marker", Marker, queue_size=10)
-        self.pinger_finder_srv = rospy.Service(
-            'hydrophones/find_pinger', FindPinger, self.find_pinger)
-        self.activate_listening = rospy.Service(
-            'hydrophones/set_listen', SetBool, self.set_listen)
-        self.set_freq_srv = rospy.Service(
-            'hydrophones/set_freq', SetFrequency, self.set_freq)
+        self.ping_sub = rospy.Subscriber("/hydrophones/processed", ProcessedPing, callback=self.ping_cb)
+        self.marker_pub = rospy.Publisher("/visualization_marker", Marker, queue_size=10)
+        self.pinger_finder_srv = rospy.Service('hydrophones/find_pinger', FindPinger, self.find_pinger)
+        self.activate_listening = rospy.Service('hydrophones/set_listen', SetBool, self.set_listen)
+        self.set_freq_srv = rospy.Service('hydrophones/set_freq', SetFrequency, self.set_freq)
 
     def ping_cb(self, ping):
         print rospkg.get_ros_package_path()
@@ -63,10 +57,8 @@ class PingerFinder(object):
         if abs(ping.freq - self.target_freq) < self.freq_tol and ping.amplitude > self.min_amp and self.listen:
             trans, rot = None, None
             try:
-                self.tf_listener.waitForTransform(
-                    self.map_frame, self.hydrophone_frame, ping.header.stamp, rospy.Duration(0.25))
-                trans, rot = self.tf_listener.lookupTransform(
-                    self.map_frame, self.hydrophone_frame, ping.header.stamp)
+                self.tf_listener.waitForTransform(self.map_frame, self.hydrophone_frame, ping.header.stamp, rospy.Duration(0.25))
+                trans, rot = self.tf_listener.lookupTransform(self.map_frame, self.hydrophone_frame, ping.header.stamp)
             except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException) as e:
                 print e
                 return
@@ -74,20 +66,14 @@ class PingerFinder(object):
             R = tf.transformations.quaternion_matrix(rot)[:3, :3]
             delta = R.dot(navigator_tools.point_to_numpy(ping.position))[:2]
             p1 = p0 + self.heading_pseudorange * delta / npl.norm(delta)
-            # p0 and p1 define a line
-            line_coeffs = np.array([[p0[0], p0[1], p1[0], p1[1]]])
-            self.visualize_arrow(
-                Point(p0[0], p0[1], 0), Point(p1[0], p1[1], 0))
+            line_coeffs = np.array([[p0[0], p0[1], p1[0], p1[1]]]) # p0 and p1 define a line
+            self.visualize_arrow(Point(p0[0], p0[1], 0), Point(p1[0], p1[1], 0))
             self.line_array = np.append(self.line_array, line_coeffs, 0)
-            self.observation_amplitudes = np.append(
-                self.observation_amplitudes, ping.amplitude)
-            # delete softest samples if we have over max_observations
-            if len(self.line_array) >= self.max_observations:
+            self.observation_amplitudes = np.append(self.observation_amplitudes, ping.amplitude)
+            if len(self.line_array) >= self.max_observations:  # delete softest samples if we have over max_observations
                 softest_idx = np.argmin(self.observation_amplitudes)
-                self.line_array = np.delete(
-                    self.line_array, softest_idx, axis=0)
-                self.observation_amplitudes = np.delete(
-                    self.observation_amplitudes, softest_idx)
+                self.line_array = np.delete(self.line_array, softest_idx, axis=0)  
+                self.observation_amplitudes = np.delete(self.observation_amplitudes, softest_idx)
             print "PINGERFINDER: Observation collected. Total: {}".format(self.line_array.shape[0])
 
     def LS_intersection(self):
@@ -105,11 +91,9 @@ class PingerFinder(object):
 
         begin_pts = self.line_array[:, :2]
         diffs = self.line_array[:, 2:4] - begin_pts
-        norms = np.apply_along_axis(
-            line_segment_norm, 1, self.line_array).reshape(diffs.shape[0], 1)
+        norms = np.apply_along_axis(line_segment_norm, 1, self.line_array).reshape(diffs.shape[0], 1)
         rot_left_90 = np.array([[0, -1], [1, 0]])
-        perp_unit_vecs = np.apply_along_axis(
-            lambda unit_diffs: rot_left_90.dot(unit_diffs), 1, diffs / norms)
+        perp_unit_vecs = np.apply_along_axis(lambda unit_diffs: rot_left_90.dot(unit_diffs), 1, diffs / norms)
         A_sum = np.zeros((2, 2))
         Ap_sum = np.zeros((2, 1))
 
@@ -129,8 +113,7 @@ class PingerFinder(object):
         if self.line_array.shape[0] < 2:
             print "PINGER_FINDER: Can't locate pinger. Less than two valid observations have been recorded."
             return {}
-        res = {'pinger_position': self.LS_intersection(
-        ), 'num_samples': self.line_array.shape[0]}
+        res =  {'pinger_position' : self.LS_intersection(), 'num_samples' : self.line_array.shape[0]}
         self.visualize_pinger()
         return res
 
@@ -150,6 +133,7 @@ class PingerFinder(object):
         if self.pinger_position != Point(0, 0, 0):
             self.marker_pub.publish(marker)
             print "PINGERFINDER: position: ({p.x[0]:.2f}, {p.y[0]:.2f})".format(p=self.pinger_position)
+                 
 
     def visualize_arrow(self, tail, head):
         marker = Marker()
@@ -170,7 +154,7 @@ class PingerFinder(object):
         marker.color.b = 1.0
         marker.color.a = 0.5
         self.marker_pub.publish(marker)
-
+        
     def set_listen(self, listen_status):
         self.listen = listen_status.data
         print "PINGERFINDER: setting listening to on" if self.listen else "PINGERFINDER: setting listening to off"
@@ -182,7 +166,6 @@ class PingerFinder(object):
         self.sample_amplitudes = np.empty((0, 0), float)
         self.pinger_position = Point(0, 0, 0)
         return SetFrequencyResponse()
-
 
 if __name__ == '__main__':
     rospy.init_node('pinger_finder')

--- a/utils/mil_tools/include/mil_tools/msg_helpers.hpp
+++ b/utils/mil_tools/include/mil_tools/msg_helpers.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <tf/tf.h>
 #include <Eigen/Dense>
+#include <tf/tf.h>
 
-namespace mil_tools
-{
+namespace mil_tools {
+
 template <class T>
-inline T make_rgba(double r, double g, double b, double a)
-{
+inline T make_rgba(double r, double g, double b, double a) {
   T c;
   c.r = r;
   c.g = g;
@@ -17,8 +16,7 @@ inline T make_rgba(double r, double g, double b, double a)
 }
 
 template <class T>
-inline T make_xyz(double x, double y, double z)
-{
+inline T make_xyz(double x, double y, double z) {
   T p;
   p.x = x;
   p.y = y;
@@ -27,41 +25,29 @@ inline T make_xyz(double x, double y, double z)
 }
 
 template <class T>
-inline T vec2xyz(Eigen::Vector3d v)
-{
+inline T vec2xyz(Eigen::Vector3d v) {
   return make_xyz<T>(v(0), v(1), v(2));
 }
 template <class T>
-inline T vec2xyz(tf::Vector3 v)
-{
+inline T vec2xyz(tf::Vector3 v) {
   return make_xyz<T>(v.x(), v.y(), v.z());
 }
 template <class T>
-inline Eigen::Vector3d xyz2vec(T m)
-{
+inline Eigen::Vector3d xyz2vec(T m) {
   return Eigen::Vector3d(m.x, m.y, m.z);
 }
 
-inline Eigen::Vector3d vec2vec(tf::Vector3 v)
-{
-  return Eigen::Vector3d(v[0], v[1], v[2]);
-}
-inline tf::Vector3 vec2vec(Eigen::Vector3d v)
-{
-  return tf::Vector3(v[0], v[1], v[2]);
-}
-inline Eigen::Quaterniond quat2quat(const tf::Quaternion &q)
-{
+inline Eigen::Vector3d vec2vec(tf::Vector3 v) { return Eigen::Vector3d(v[0], v[1], v[2]); }
+inline tf::Vector3 vec2vec(Eigen::Vector3d v) { return tf::Vector3(v[0], v[1], v[2]); }
+inline Eigen::Quaterniond quat2quat(const tf::Quaternion &q) {
   return Eigen::Quaterniond(q[3], q[0], q[1], q[2]);
 }
-inline tf::Quaternion quat2quat(const Eigen::Quaterniond &q)
-{
+inline tf::Quaternion quat2quat(const Eigen::Quaterniond &q) {
   return tf::Quaternion(q.x(), q.y(), q.z(), q.w());
 }
 
 template <class T>
-inline T make_xyzw(double x, double y, double z, double w)
-{
+inline T make_xyzw(double x, double y, double z, double w) {
   T q;
   q.x = x;
   q.y = y;
@@ -71,27 +57,21 @@ inline T make_xyzw(double x, double y, double z, double w)
 }
 
 template <class T>
-inline T vec2xyzw(Eigen::Vector4d v)
-{
+inline T vec2xyzw(Eigen::Vector4d v) {
   return vec2xyzw<T>(v(0), v(1), v(2), v(3));
 }
 template <class T>
-inline Eigen::Quaterniond xyzw2quat(T m)
-{
+inline Eigen::Quaterniond xyzw2quat(T m) {
   return Eigen::Quaterniond(m.w, m.x, m.y, m.z);
 }
 template <class T>
-inline T vec2wxyz(Eigen::Vector4d v)
-{
+inline T vec2wxyz(Eigen::Vector4d v) {
   return make_xyzw<T>(v(1), v(2), v(3), v(0));
 }
-inline tf::Quaternion vec2quat(Eigen::Vector4d v)
-{
-  return tf::Quaternion(v[0], v[1], v[2], v[3]);
-}
+inline tf::Quaternion vec2quat(Eigen::Vector4d v) { return tf::Quaternion(v[0], v[1], v[2], v[3]); }
 template <class T>
-inline T quat2xyzw(Eigen::Quaterniond q)
-{
+inline T quat2xyzw(Eigen::Quaterniond q) {
   return make_xyzw<T>(q.x(), q.y(), q.z(), q.w());
 }
 }
+

--- a/utils/mil_tools/include/mil_tools/param_helpers.hpp
+++ b/utils/mil_tools/include/mil_tools/param_helpers.hpp
@@ -6,100 +6,79 @@
 
 #include <mil_tools/msg_helpers.hpp>
 
-namespace mil_tools
-{
-void fail(std::string const &error_string)
-{
-  throw std::runtime_error(error_string);
-}
+namespace mil_tools {
+
+void fail(std::string const &error_string) { throw std::runtime_error(error_string); }
 template <typename FirstType, typename SecondType, typename... MoreTypes>
-void fail(FirstType first, SecondType second, MoreTypes... more)
-{
+void fail(FirstType first, SecondType second, MoreTypes... more) {
   std::ostringstream ss;
   ss << first << second;
   return fail(ss.str(), more...);
 }
 
 template <typename... ErrorDescTypes>
-void require(bool cond, ErrorDescTypes... error_desc)
-{
-  if (!cond)
-  {
+void require(bool cond, ErrorDescTypes... error_desc) {
+  if (!cond) {
     fail(error_desc...);
   }
 }
 
 template <typename T, int N>
-bool _getParam(ros::NodeHandle &nh, const std::string &name, Eigen::Matrix<T, N, 1> &res)
-{
+bool _getParam(ros::NodeHandle &nh, const std::string &name, Eigen::Matrix<T, N, 1> &res) {
   XmlRpc::XmlRpcValue my_list;
-  if (!nh.getParam(name, my_list))
-    return false;
+  if (!nh.getParam(name, my_list)) return false;
   require(my_list.getType() == XmlRpc::XmlRpcValue::TypeArray, "param ", name, " must be an array");
-  if (N != Eigen::Dynamic)
-  {
-    require(my_list.size() == N, "param ", name, "must have length ", N, " (is ", my_list.size(), ")");
+  if (N != Eigen::Dynamic) {
+    require(my_list.size() == N, "param ", name, "must have length ", N, " (is ", my_list.size(),
+            ")");
   }
 
   res.resize(my_list.size());
-  for (int32_t i = 0; i < my_list.size(); i++)
-  {
-    if (my_list[i].getType() == XmlRpc::XmlRpcValue::TypeDouble)
-    {
+  for (int32_t i = 0; i < my_list.size(); i++) {
+    if (my_list[i].getType() == XmlRpc::XmlRpcValue::TypeDouble) {
       res(i) = static_cast<double>(my_list[i]);
-    }
-    else if (my_list[i].getType() == XmlRpc::XmlRpcValue::TypeInt)
-    {
+    } else if (my_list[i].getType() == XmlRpc::XmlRpcValue::TypeInt) {
       res(i) = static_cast<int>(my_list[i]);
-    }
-    else
-    {
+    } else {
       fail("param ", name, "[", i, "] is not numeric");
     }
   }
   return true;
 }
 template <typename T, int N, int M>
-bool _getParam(ros::NodeHandle &nh, const std::string &name, Eigen::Matrix<T, N, M> &res)
-{
+bool _getParam(ros::NodeHandle &nh, const std::string &name, Eigen::Matrix<T, N, M> &res) {
   static_assert(N != 0, "doesn't work for N = 0");
   static_assert(M != 1, "wrong template specialization used?");
 
   XmlRpc::XmlRpcValue my_list;
-  if (!nh.getParam(name, my_list))
-    return false;
+  if (!nh.getParam(name, my_list)) return false;
   require(my_list.getType() == XmlRpc::XmlRpcValue::TypeArray, "param ", name, " must be an array");
   require(my_list.size() >= 1, "param " + name + " must not have zero length");
-  if (N != Eigen::Dynamic)
-  {
-    require(my_list.size() == N, "param ", name, "must have length ", N, " (is ", my_list.size(), ")");
+  if (N != Eigen::Dynamic) {
+    require(my_list.size() == N, "param ", name, "must have length ", N, " (is ", my_list.size(),
+            ")");
   }
 
-  require(my_list[0].getType() == XmlRpc::XmlRpcValue::TypeArray, "param ", name, "[0] must be a list");
-  if (M != Eigen::Dynamic)
-  {
-    require(my_list[0].size() == M, "param ", name, "[0] must have length ", M, " (is ", my_list[0].size(), ")");
+  require(my_list[0].getType() == XmlRpc::XmlRpcValue::TypeArray, "param ", name,
+          "[0] must be a list");
+  if (M != Eigen::Dynamic) {
+    require(my_list[0].size() == M, "param ", name, "[0] must have length ", M, " (is ",
+            my_list[0].size(), ")");
   }
 
   res.resize(my_list.size(), my_list[0].size());
-  for (int32_t i = 0; i < my_list.size(); i++)
-  {
+  for (int32_t i = 0; i < my_list.size(); i++) {
     XmlRpc::XmlRpcValue row = my_list[i];
-    require(row.getType() == XmlRpc::XmlRpcValue::TypeArray, "param ", name, "[", i, "] must be a list");
+    require(row.getType() == XmlRpc::XmlRpcValue::TypeArray, "param ", name, "[", i,
+            "] must be a list");
     require(row.size() == my_list[0].size(), "param ", name, "[", i, "]'s length doesn't match");
-    for (int32_t j = 0; j < row.size(); j++)
-    {
+    for (int32_t j = 0; j < row.size(); j++) {
       XmlRpc::XmlRpcValue entry = row[j];
-      if (entry.getType() == XmlRpc::XmlRpcValue::TypeDouble)
-      {
+      if (entry.getType() == XmlRpc::XmlRpcValue::TypeDouble) {
         res(i, j) = static_cast<double>(entry);
-      }
-      else if (entry.getType() == XmlRpc::XmlRpcValue::TypeInt)
-      {
+      } else if (entry.getType() == XmlRpc::XmlRpcValue::TypeInt) {
         res(i, j) = static_cast<int>(entry);
-      }
-      else
-      {
+      } else {
         fail("param ", name, "[", i, ", ", j, "] is not numeric");
       }
     }
@@ -107,27 +86,21 @@ bool _getParam(ros::NodeHandle &nh, const std::string &name, Eigen::Matrix<T, N,
   return true;
 }
 template <typename T>
-bool _getParam(ros::NodeHandle &nh, const std::string &name, T &res)
-{
+bool _getParam(ros::NodeHandle &nh, const std::string &name, T &res) {
   return nh.getParam(name, res);
 }
 template <>
-bool _getParam(ros::NodeHandle &nh, const std::string &name, ros::Duration &res)
-{
+bool _getParam(ros::NodeHandle &nh, const std::string &name, ros::Duration &res) {
   double x;
-  if (!nh.getParam(name, x))
-    return false;
+  if (!nh.getParam(name, x)) return false;
   res = ros::Duration(x);
   return true;
 }
 template <>
-bool _getParam(ros::NodeHandle &nh, const std::string &name, unsigned int &res)
-{
+bool _getParam(ros::NodeHandle &nh, const std::string &name, unsigned int &res) {
   int x;
-  if (!nh.getParam(name, x))
-    return false;
-  if (x < 0)
-  {
+  if (!nh.getParam(name, x)) return false;
+  if (x < 0) {
     fail("param ", name, " must be >= 0");
   }
   res = static_cast<unsigned int>(x);
@@ -135,20 +108,18 @@ bool _getParam(ros::NodeHandle &nh, const std::string &name, unsigned int &res)
 }
 
 template <typename T>
-T getParam(ros::NodeHandle &nh, std::string name)
-{
+T getParam(ros::NodeHandle &nh, std::string name) {
   T res;
   require(_getParam(nh, name, res), "param ", name, " required");
   return res;
 }
 template <typename T>
-T getParam(ros::NodeHandle &nh, std::string name, T default_value)
-{
+T getParam(ros::NodeHandle &nh, std::string name, T default_value) {
   T res;
-  if (!_getParam(nh, name, res))
-  {
+  if (!_getParam(nh, name, res)) {
     return default_value;
   }
   return res;
 }
 }
+


### PR DESCRIPTION
The purpose of this pull request is to resolve the merge conflicts that were created on #17 as a result of automatic Python and C++ formatting. It rolls back changes made to the following files in commits `d9e497a30c0699c177e6193d4d505c69de8f1209` and `c8dc92891ba2031c95dac285a201d66d5887ae39`:

    drivers/mil_passive_sonar/mil_passive_sonar/sonar_driver.py
    drivers/mil_passive_sonar/multilateration/multilateration.py
    drivers/mil_passive_sonar/nodes/pinger_finder.py
    utils/mil_tools/include/mil_tools/msg_helpers.hpp
    utils/mil_tools/include/mil_tools/param_helpers.hpp