### PR TITLE
SCRIPTS: Add aliases for tmux and wsmux play nice

### DIFF
--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -28,10 +28,15 @@ ros_env() {
 
 
 # Directory navigation
+alias ws="cd \$CATKIN_DIR"
 alias mc="cd \$CATKIN_DIR/src/mil_common"
 
 # Bash sourcing
 alias srcbrc="source ~/.bashrc"
+
+# Workspace specific and shared tmux sockets
+alias tmux="tmux -L \$(echo \$CATKIN_DIR | rev | cut -d '/' -f1 | rev)"
+alias shared-tmux="tmux -L mil_ws"
 
 # Catkin workspace management
 alias cm="catkin_make -C \$CATKIN_DIR -j8"


### PR DESCRIPTION
At testing today, it was discovered that specifying a different `tmux` socket for each user fixed a lot of the issues involving tmux environment variables and configurations. A `tmux` alias is set to change the socket from `default` to the name of the current workspace.

Because each workspace, and therefore each user, is now on a separate socket, users will not be able to connect to each others tmux sessions without manually passing in the socket name for that user. To allow shared sessions, the `smux` alias was created. This alias simply sets the socket to `mil_ws`, which everyone should have access to. **Launch `tmux` sessions should be opened with `smux` so that everyone can access them**.

Specifying a custom `tmux` or `vim` configuration can now be done in the `.wsrc` file at the root of a workspace. Make sure that the `tmux` alias that is created is in the same vein as the one that was created in this pull request so that your socket is based on your workspace.

The `ws` alias was suggested by @DSsoto. It simply moves the user to their currently sourced workspace.