### PR TITLE
VISION, MISC: add some helper vision tools and misc

### DIFF
--- a/perception/mil_vision/mil_vision_tools/__init__.py
+++ b/perception/mil_vision/mil_vision_tools/__init__.py
@@ -1,2 +1,2 @@
-from rect_finder import RectFinder
+from shape_finder import RectFinder, EllipseFinder, CircleFinder
 from threshold import Threshold

--- a/perception/mil_vision/mil_vision_tools/__init__.py
+++ b/perception/mil_vision/mil_vision_tools/__init__.py
@@ -1,2 +1,2 @@
 from shape_finder import RectFinder, EllipseFinder, CircleFinder
-from threshold import Threshold
+from cv_tools import Threshold, auto_canny

--- a/perception/mil_vision/mil_vision_tools/__init__.py
+++ b/perception/mil_vision/mil_vision_tools/__init__.py
@@ -1,1 +1,2 @@
 from rect_finder import RectFinder
+from threshold import Threshold

--- a/perception/mil_vision/mil_vision_tools/cv_tools.py
+++ b/perception/mil_vision/mil_vision_tools/cv_tools.py
@@ -115,3 +115,22 @@ class Threshold(object):
 
     def __repr__(self):
         return str((self.low, self.high, self.conversion_code))
+
+
+def auto_canny(image, sigma=0.33):
+    '''
+    Returns a binary image of the edges in an image.
+    Uses the median of the image to pick good low and upper threshold values
+    for Canny, which makes it both adaptive and require less tunning.
+
+    @param image grayscale image to find edges in
+    @param sigma 0-1 float, how aggressively to find edges in an image, where
+           1 will produce the most edges but also the most noise
+
+    Credit Adrian Rosebrock
+    http://www.pyimagesearch.com/2015/04/06/zero-parameter-automatic-canny-edge-detection-with-python-and-opencv/
+    '''
+    m = np.median(image)
+    lower = int(max(0, (1.0 - sigma) * m))
+    upper = int(min(255, (1.0 + sigma) * m))
+    return cv2.Canny(image, lower, upper)

--- a/perception/mil_vision/mil_vision_tools/threshold.py
+++ b/perception/mil_vision/mil_vision_tools/threshold.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+import cv2
+import rospy
+import numpy as np
+
+__author__ = "Kevin Allen"
+
+
+class Threshold(object):
+    def __init__(self, low, high, conversion_code=None, in_space='BGR', thresh_space='BGR'):
+        '''
+        Convience class to store lower and upper bounds for doing a color threshold in OpenCV
+
+        See examples for clearer understanding of parameters.
+        @param low A list represnting the lower acceptable values for thresholding an image
+        @param high A list representing the high acceptable values for thresholding an image
+        @param conversion_code When not None, passed to cv2.cvtColor to change colorspace before thresholding image
+        @param in_space All caps string that's a valid OpenCV colorspace ('HSV', 'BGR', 'LAB', etc),
+                        used to determine conversion_code if conversion_code is None
+        @param thresh_space All caps string that's a valid OpenCV colorspace, used to convert
+                            image before thresholding. Used to determine conversion_code if it's None
+
+        ex:
+        Threshold((0, 0, 0), (255, 255, 255)) # Thresholds BGR image in BGR colorpace
+        Threshold([25, 180 180], np.array([50, 190, 200]), thresh_space='LAB')  # Thresholds BGR image in LAB
+        Threshold((50, 50, 50), [200, 200, 200], in_space='HSV', thresh_space='LAB') # Threshold HSV image in LAB
+        '''
+        assert isinstance(low, (tuple, list, np.ndarray)), 'param lower must be a tuple/list/np.ndarray'
+        assert isinstance(high, (tuple, list, np.ndarray)), 'param upper must be a tuple/list/np.ndarray'
+        self.low = np.array(low)
+        self.high = np.array(high)
+        self.in_space = in_space
+        self.thresh_space = thresh_space
+        # If conversion code not specified, try to form it from other params
+        if conversion_code is None and in_space != thresh_space:
+            try:
+                self.conversion_code = getattr(cv2, 'COLOR_{}2{}'.format(in_space, thresh_space))
+            except AttributeError:
+                raise Exception('Could not determine conversion code from params.\
+                                 Are [{}, {}] valid OpenCV colorspaces?'.format(in_space, thresh_space))
+        else:
+            self.conversion_code = conversion_code
+
+    @classmethod
+    def from_dict(cls, d, in_space='BGR', thresh_space=None):
+        '''
+        Loads thresholds from a dictionary. See examples for valid dictionaries.
+
+        @param in_space See __init__ for valid values.
+        @param thresh_space If None, loads threshold in colorspace of first key in dictionary.
+                            Otherwise, see __init__ for valid values
+        Valid Examples:
+
+        { 'HSV':
+            'low': [0, 20, 50],
+            'high': [255, 255, 255] }
+        -> Threshold([0, 20, 50], [255, 255, 255], thresh_space='HSV')
+
+        { 'LAB': [0, 66, 66], [255, 180, 180] }
+        -> Threshold([0, 66, 66], [255, 180, 180], thresh_space='LAB')
+        '''
+        assert isinstance(d, dict), 'd is not a dictionary'
+        if thresh_space is None:
+            assert len(d) > 0, 'Dictionary is empty'
+            return cls.from_dict(d, in_space=in_space, thresh_space=d.keys()[0])
+        assert thresh_space in d, '{} color space not in dictionary'.format(thresh_space)
+        inner = d[thresh_space]
+        if 'low' in inner and 'high' in inner:
+            return cls(inner['low'], inner['high'], in_space=in_space, thresh_space=thresh_space)
+        assert len(inner) == 2, 'Cannot get low and high bounds from dictionary'
+        return cls(inner[0], inner[1], in_space=in_space, thresh_space=thresh_space)
+
+    @classmethod
+    def from_param(cls, param, in_space='BGR', thresh_space=None):
+        '''
+        Loads thresholds from a ROS param. Param must be a valid dictionary, see from_dict
+        '''
+        return cls.from_dict(rospy.get_param(param), in_space=in_space, thresh_space=thresh_space)
+
+    def threshold(self, img):
+        if self.conversion_code is not None:
+            converted = cv2.cvtColor(img, self.conversion_code)
+            return cv2.inRange(converted, self.low, self.high)
+        return cv2.inRange(img, self.low, self.high)
+
+    __call__ = threshold  # Calling this will threshold an image
+
+    def create_trackbars(self, window=None):
+        '''
+        Create OpenCV GUI trackbars to adjust the threshold values live.
+
+        @param window Name of OpenCV window to put trackbars in
+        '''
+        if window is None:
+            window = 'threshold'
+            cv2.namedWindow(window)
+
+        def set_thresh(t, i, x):
+            if t == 'low':
+                self.low[i] = x
+            if t == 'high':
+                self.high[i] = x
+        for i in range(len(self.low)):
+            cv2.createTrackbar('low {}'.format(i), window, int(self.low[i]), 255,
+                               lambda x, _self=self, _i=i: set_thresh('low', _i, x))
+        for i in range(len(self.high)):
+            cv2.createTrackbar('high {}'.format(i), window, int(self.high[i]), 255,
+                               lambda x, _self=self, _i=i: set_thresh('high', _i, x))
+
+    def __str__(self):
+        if self.conversion_code is not None:
+            return 'Threshold from {} to {} using conversion code {}'.format(self.low, self.high, self.conversion_code)
+        return 'Threshold {} images in {} colorspace from {} to {}'.format(
+            self.in_space, self.thresh_space, self.low, self.high)
+
+    def __repr__(self):
+        return str((self.low, self.high, self.conversion_code))

--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -43,3 +43,6 @@ alias cm="catkin_make -C \$CATKIN_DIR -j8"
 
 # Simulation
 alias killgazebo="killall -9 gazebo && killall -9 gzserver && killall -9 gzclient"
+
+# Formatting (be sure to update with Jenkinsfile)
+alias mcfmt="python2.7 -m flake8 --ignore E731 --max-line-length=120 --exclude=__init__.py,drivers/mil_passive_sonar \$CATKIN_DIR/src/mil_common"

--- a/utils/mil_tools/mil_ros_tools/fix_bag.py
+++ b/utils/mil_tools/mil_ros_tools/fix_bag.py
@@ -2,6 +2,7 @@
 import argparse
 import rosbag
 import rospy
+from tqdm import tqdm
 
 
 class BagFixer():
@@ -45,10 +46,12 @@ class BagFixer():
             start = first_time + rospy.Duration(self.start)
         if self.stop is not None:
             stop = first_time + rospy.Duration(self.stop)
+        total_messages = bag.get_message_count()
         # This could be made signifigantly faster by using ag.get_type_and_topic_info
         # to do some preprocessing on what topics will be used / remaped /
         # processed
-        for topic, msg, time in bag.read_messages(start_time=start, end_time=stop):
+        for topic, msg, time in tqdm(bag.read_messages(start_time=start, end_time=stop),
+                                     total=total_messages, unit=' messages', desc='Fixing bag'):
             if not self.valid_topic(topic):
                 continue
             topic = self.fix_topic(topic)


### PR DESCRIPTION
* add milfmt alias, which will run flake8 on your mil_common repo so you can see pep8 violations before submitting a PR
* add a cute TQDM progressbar to fix_bar.py, so the user can get a rough idea on how long the program will run instead of just idling for minutes without feedback
* Add cv_tools.py, for OpenCV helper functions/classes
  * Added threshold class, which will load color threshold values in any valid colorspace from a ros param so individual perception nodes don't have to implement this
  * Added auto_canny, an adaptive Canny threshold to reduce time spent tunny Canny threshold values
* Added EllipseFinder, a class which extends RectFinder to also allow ellipse contours