### PR TITLE
CAMERA_STREAM: fix mutex

### DIFF
--- a/perception/mil_vision/include/mil_vision_lib/image_acquisition/ros_camera_stream.hpp
+++ b/perception/mil_vision/include/mil_vision_lib/image_acquisition/ros_camera_stream.hpp
@@ -292,6 +292,7 @@ operator[](int i)
   {
     auto err = "ROSCameraStream: The circular buffer index you are trying to acess is out of bounds:\n"_s + e.what();
     ROS_WARN_THROTTLE_NAMED(1, "ROSCameraStream", err.c_str());
+    _mtx.unlock();
     return nullptr;
   }
 


### PR DESCRIPTION
Ran into a sort of race condition where the buffer has yet to receive an image.

Here's the backtace:
.1  0x00007ffff2bdb02a in __GI_abort () at abort.c:89
.2  0x00007ffff2bd1bd7 in __assert_fail_base (fmt=<optimized out>, 
    assertion=assertion@entry=0x793f5c "index < size()", 
    file=file@entry=0x793f30 "/usr/include/boost/circular_buffer/base.hpp", line=line@entry=384, 
    function=function@entry=0x794680 <boost::circular_buffer<std::shared_ptr<mil_vision::CameraFrame<std::shared_ptr<image_geometry::PinholeCameraModel>, cv::Vec<unsigned char, 3>, ros::Time, float> >, std::allocator<std::shared_ptr<mil_vision::CameraFrame<std::shared_ptr<image_geometry::PinholeCameraModel>, cv::Vec<unsigned char, 3>, ros::Time, float> > > >::operator[](unsigned long)::__PRETTY_FUNCTION__> "boost::circular_buffer<T, Alloc>::reference boost::circular_buffer<T, Alloc>::operator[](boost::circular_buffer<T, Alloc>::size_type) [with T = std::shared_ptr<mil_vision::CameraFrame<std::shared_ptr<"...)
    at assert.c:92
.3  0x00007ffff2bd1c82 in __GI___assert_fail (
    assertion=0x793f5c "index < size()", 
    file=0x793f30 "/usr/include/boost/circular_buffer/base.hpp", 
    line=384, 
    function=0x794680 <boost::circular_buffer<std::shared_ptr<mil_vision::CameraFrame<std::shared_ptr<image_geometry::PinholeCameraModel>, cv::Vec<unsigned char, 3>, ros::Time, float> >, std::allocator<std::shared_ptr<mil_vision::CameraFrame<std::shared_ptr<image_geometry::Pi---Type <return> to continue, or q <return> to quit---
nholeCameraModel>, cv::Vec<unsigned char, 3>, ros::Time, float> > > >::operator[](unsigned long)::__PRETTY_FUNCTION__> "boost::circular_buffer<T, Alloc>::reference boost::circular_buffer<T, Alloc>::operator[](boost::circular_buffer<T, Alloc>::size_type) [with T = std::shared_ptr<mil_vision::CameraFrame<std::shared_ptr<"...) at assert.c:101
.4  0x00000000006d5383 in boost::circular_buffer<std::shared_ptr<mil_vision::CameraFrame<std::shared_ptr<image_geometry::PinholeCameraModel>, cv::Vec<unsigned char, 3>, ros::Time, float> >, std::allocator<std::shared_ptr<mil_vision::CameraFrame<std::shared_ptr<image_geometry::PinholeCameraModel>, cv::Vec<unsigned char, 3>, ros::Time, float> > > >::operator[] (this=0xaf12a0, index=0)
    at /usr/include/boost/circular_buffer/base.hpp:384

.5  0x00000000006d4071 in mil_vision::ROSCameraStream<cv::Vec<unsigned char, 3>, float>::operator[] (this=0xaf1298, i=0)
    at /home/daniel/mil_ws/src/mil_common/perception/mil_vision/include/mil_vision_lib/image_acquisition/ros_camera_stream.hpp:283