### PR TITLE
SCRIPTS: make cm alias leave a free core

### DIFF
--- a/scripts/bash_aliases.sh
+++ b/scripts/bash_aliases.sh
@@ -39,7 +39,7 @@ alias tmux="tmux -L \$(echo \$CATKIN_DIR | rev | cut -d '/' -f1 | rev)"
 alias shared-tmux="tmux -L mil_ws"
 
 # Catkin workspace management
-alias cm="catkin_make -C \$CATKIN_DIR -j8"
+alias cm="catkin_make -C \$CATKIN_DIR -j$(($(nproc)-1))"
 
 # Simulation
 alias killgazebo="killall -9 gazebo && killall -9 gzserver && killall -9 gzclient"


### PR DESCRIPTION
* Detects the number of cores on your system and sets the value of the
  -j* flag to use one less than the number of available cores