### PR TITLE
TOOLS, CI: only run tests in specified directory

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,8 @@ dockerNode(image: 'uf-mil:mil_common') {
 		sh '''
 			source ~/.mil/milrc > /dev/null 2>&1
 			source $CATKIN_DIR/devel/setup.bash > /dev/null 2>&1
-			catkin_make -C $CATKIN_DIR run_tests
+			cd $CATKIN_DIR
+			rosrun mil_tools catkin_tests_directory.py src/mil_common -i ros_alarms velodyne_driver velodyne_pointcloud pointgrey_camera_driver
 			catkin_test_results $CATKIN_DIR/build/test_results --verbose
 		'''
 	}

--- a/utils/mil_tools/mil_ros_tools/catkin_tests_directory.py
+++ b/utils/mil_tools/mil_ros_tools/catkin_tests_directory.py
@@ -28,8 +28,9 @@ def get_packages(directory):
 
 
 def run_tests(tests):
-    cmd = ["catkin_make"] + tests
-    return subprocess.call(cmd)
+    cmd = 'catkin_make ' + ' '.join(tests)
+    print cmd
+    return subprocess.call(cmd.split())
 
 
 if __name__ == '__main__':

--- a/utils/mil_tools/mil_ros_tools/catkin_tests_directory.py
+++ b/utils/mil_tools/mil_ros_tools/catkin_tests_directory.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+import subprocess
+import argparse
+import sys
+
+"""
+Script to run all catkin tests in a specified directory. Useful in CI systems where you only need
+to test some of the packages
+
+ex usage:
+    rosurn mil_tools catkin_tests_directory.py src/NaviGator
+"""
+
+
+def get_tests(directory):
+    cmd = "make -C {}".format(directory)
+    cmd += "  -qp | awk -F':' '/^[a-zA-Z0-9][^$#\/\t=]*:([^=]|$)/ {split($1,A,/ /);for(i in A)print A[i]}'"
+    tests = subprocess.check_output(["bash", "-c", cmd])
+    tests = tests.split()
+    return tests
+
+
+def get_packages(directory):
+    cmd = "catkin_topological_order --only-names {}".format(directory)
+    packages = subprocess.check_output(["bash", "-c", cmd])
+    packages = packages.split()
+    return packages
+
+
+def run_tests(tests):
+    cmd = ["catkin_make"] + tests
+    return subprocess.call(cmd)
+
+
+if __name__ == '__main__':
+    # parse configuration from arguments
+    parser = argparse.ArgumentParser(description='Prints all catkin test targets in a specified directory')
+    parser.add_argument('directory', type=str, default="src", nargs='?', help="directory to print all tests frome")
+    parser.add_argument('-b', '--build-dir', dest="build_dir", type=str,
+                        default="build", help="build directory of workspace with tests")
+    parser.add_argument('--ignore-dir', '-i', dest='ignore', type=str, nargs='*', help="packages to ignore")
+    args = parser.parse_args(sys.argv[1:])
+
+    # get all available tests in workspace
+    tests = get_tests(args.build_dir)
+    if len(tests) < 1:
+        print 'no tests found'
+        exit(1)
+
+    # get all packages in specified directory
+    packages = get_packages(args.directory)
+    if args.ignore is not None:  # Filter out ignored packages
+        packages = filter(lambda p: p not in args.ignore, packages)
+    if len(packages) < 1:
+        print 'no packages found'
+        exit(1)
+
+    # produce a list of all test build targets from a package in the specified folders
+    valid = []
+    for p in packages:
+        test = 'run_tests_{}'.format(p)
+        if test in tests:
+            valid.append(test)
+    if len(valid) < 1:
+        print 'No tests found'
+        exit(1)
+
+    # run catkin
+    exit(run_tests(valid))


### PR DESCRIPTION
Adds a script to only run catkin tests in a certain directory (all packages in that directory), for use in MIL CI so we don't get failing builds for submodules and other projects.