### PR TITLE
ROS_DOCKER: Add Dockerfile and python script for managing ROS docker

### DIFF
--- a/scripts/ros_docker_controller/Dockerfile
+++ b/scripts/ros_docker_controller/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     python-rosdep \
     python-rosinstall \
     python-vcstools \
-    wget \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # setup environment
@@ -54,6 +54,8 @@ USER mil
 WORKDIR /home/mil
 SHELL ["/bin/bash", "-c"]
 
+RUN mkdir .ssh
+
 # bootstrap rosdep
 RUN sudo rosdep init \
     && rosdep update
@@ -65,5 +67,7 @@ RUN  sudo apt-get -y clean \
 	&& sudo rm -rf /var/lib/apt/lists/* \
     && sudo rm -f /var/cache/apt/*.bin
 
+# Will be replaced, if selected, by ros_docker_controller script
+# COPY ssh_github_key
 
 CMD ["bash"]

--- a/scripts/ros_docker_controller/Dockerfile
+++ b/scripts/ros_docker_controller/Dockerfile
@@ -1,0 +1,69 @@
+FROM ubuntu:xenial
+
+MAINTAINER Daniel Volya (RustyBamboo)
+
+ENV TERM xterm-256color
+
+# Install the basics
+RUN apt-get update \
+	&& apt-get -y dist-upgrade \
+	&& apt-get -y install sudo \
+	&& apt-get -y install curl \
+	&& apt-get -y install wget \
+    && apt-get -y install pciutils
+
+# RUN apt-get -y install lightdm \
+RUN apt-get -y autoremove --purge \
+	&& apt-get -y clean \
+	&& rm -rf /var/lib/apt/lists/* \
+    && rm -f /var/cache/apt/*.bin
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    dirmngr \
+    gnupg2 \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup keys
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+
+# setup sources.list
+RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources.list.d/ros-latest.list
+
+# install bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    python-rosdep \
+    python-rosinstall \
+    python-vcstools \
+    wget \
+    && rm -rf /var/lib/apt/lists/*
+
+# setup environment
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
+
+ENV ROS_DISTRO kinetic
+RUN apt-get update && apt-get install -y \
+    ros-kinetic-ros-core=1.3.2-0* \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add and do user stuff
+RUN useradd --create-home --shell /bin/bash --groups sudo --password ion mil \
+    	&& echo "mil ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+
+USER mil
+WORKDIR /home/mil
+SHELL ["/bin/bash", "-c"]
+
+# bootstrap rosdep
+RUN sudo rosdep init \
+    && rosdep update
+
+RUN wget https://raw.githubusercontent.com/uf-mil/installer/master/install.sh \
+	&& chmod +x install.sh
+
+RUN  sudo apt-get -y clean \
+	&& sudo rm -rf /var/lib/apt/lists/* \
+    && sudo rm -f /var/cache/apt/*.bin
+
+
+CMD ["bash"]

--- a/scripts/ros_docker_controller/docker_controller.py
+++ b/scripts/ros_docker_controller/docker_controller.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 
-import sys,os
+import sys
+import os
 import docker
 import curses
 from cursesmenu import *
@@ -8,61 +9,87 @@ from cursesmenu.items import *
 import distutils.spawn
 import subprocess
 
+__author__ = 'Daniel Volya (RustyBamboo)'
+
+
 class DockerController(object):
 
     def __init__(self, stdscr):
         self.stdscr = stdscr
-        self.docker_client = docker.from_env()
+
+        # Check if docker server is running
+        try:
+            self.docker_client = docker.from_env()
+        except Exception:
+            assert False, 'Is Docker server running?'
+
+        # Attempt to load container, if can't then later ask user to select image
         self.container = None
+        # If container is currently running
         if "RustyROS" in [x.name for x in self.docker_client.containers.list()]:
             self.container = self.docker_client.containers.get('RustyROS')
+        # Check if container is stopped, but still exists
         else:
             try:
                 self.container = self.docker_client.containers.get('RustyROS')
                 self.container.start()
             except Exception:
                 self.container = None
-        if not self.docker_client.containers.list():
+
+        # if no docker images are avaliable, go ahead and build one
+        if not self.docker_client.images.list():
             self.brand_new_docker_image()
 
-        self.status = ""
+        # attempt to find what kind of terminal emulator is being used
         self.terminal = None
         self.find_avaliable_terminal()
-        if(self.terminal is None):
-            assert(False)
+        assert not self.terminal is None, 'No terminal found'
+
+        # run curses stuff
         self.draw()
 
+    # Finds terminal emulator
     def find_avaliable_terminal(self):
+        # possible terminal emulators, with last having largest priorty
         terminals = ["gnome-terminal", "xterm", "konsole"]
         for t in terminals:
             x = distutils.spawn.find_executable(t)
             if not x is None:
                 self.terminal = t
 
+    # Builds the docker image, and shows some info for user
     def brand_new_docker_image(self):
         self.stdscr.clear()
+
         height, width = self.stdscr.getmaxyx()
         text = "Building image..."[:width-1]
         text1 = "To view build process:"[:width-1]
         text2 = "docker ps"[:width-1]
         text3 = "docker attach NAME"[:width-1]
+
+        # Find center of window
         x = int((width // 2) - (len(text) // 2) - len(text) % 2)
         y = int((height // 2) - 2)
+
         self.stdscr.addstr(y, x, text)
         self.stdscr.addstr(y+1, x, text1)
         self.stdscr.addstr(y+2, x, text2)
         self.stdscr.addstr(y+3, x, text3)
         self.stdscr.refresh()
+
         # Assume dockerfile is in the same relative directory
         self.docker_client.images.build(path='./', tag='mil_image:latest')
 
     def open_ros_container(self, img):
+        # Shouldn't happen, but if container was already set, ignore reset
         if not self.container is None:
             return
-        # Similar to running docker run -it IMG
-        self.container = self.docker_client.containers.run(img, detach=True, tty=True, stdin_open=True, name="RustyROS")
-        self.status = self.status + "| RUNNING"
 
+        # Similar to running 'docker run -it IMG'
+        self.container = self.docker_client.containers.run(
+            img, detach=True, tty=True, stdin_open=True, name="RustyROS", hostname=os.uname()[1]+"-ros")
+
+    # Main draw application for curses
     def draw(self):
         k = 0
         cursor_x = 0
@@ -78,8 +105,9 @@ class DockerController(object):
         curses.init_pair(2, curses.COLOR_RED, curses.COLOR_BLACK)
         curses.init_pair(3, curses.COLOR_BLACK, curses.COLOR_WHITE)
 
-        # Loop where k is the last character pressed
+        # Loop until a key ('k') is pressed
         while (k == 0):
+            # draw start menu
             self.draw_start_menu(k)
             self.draw_quit_bar()
 
@@ -90,20 +118,26 @@ class DockerController(object):
             k = self.stdscr.getch()
             if k == ord('q'):
                 return
+
+        # Build image if user clicked b
         if k == ord('b'):
             self.brand_new_docker_image()
+
         self.stdscr.clear()
 
+        # If no avaliable container, then ask user to select an image
         if self.container is None:
             selected_image = self.draw_images_menu()
             self.open_ros_container(selected_image)
 
         self.stdscr.clear()
+
         while (True):
             self.stdscr.clear()
             select = self.draw_options_menu()
             if select == 0:
-                subprocess.Popen([self.terminal, '-e', 'docker exec -it RustyROS bash'])
+                subprocess.Popen(
+                    [self.terminal, '-e', 'docker exec -it RustyROS bash'])
             elif select == 1:
                 self.container.stop()
                 return
@@ -122,15 +156,14 @@ class DockerController(object):
         selection = SelectionMenu.get_selection(l)
         return selection
 
-
-
     def draw_quit_bar(self):
         height, width = self.stdscr.getmaxyx()
-        statusbarstr = "Press 'q' to exit " + self.status
+        statusbarstr = "Press 'q' to exit "
         # Render status bar
         self.stdscr.attron(curses.color_pair(3))
         self.stdscr.addstr(height-1, 0, statusbarstr)
-        self.stdscr.addstr(height-1, len(statusbarstr), " " * (width - len(statusbarstr) - 1))
+        self.stdscr.addstr(height-1, len(statusbarstr),
+                           " " * (width - len(statusbarstr) - 1))
         self.stdscr.attroff(curses.color_pair(3))
 
     def draw_start_menu(self, k):
@@ -145,8 +178,10 @@ class DockerController(object):
 
         # Centering calculations
         start_x_title = int((width // 2) - (len(title) // 2) - len(title) % 2)
-        start_x_subtitle = int((width // 2) - (len(subtitle) // 2) - len(subtitle) % 2)
-        start_x_keystr = int((width // 2) - (len(keystr) // 2) - len(keystr) % 2)
+        start_x_subtitle = int(
+            (width // 2) - (len(subtitle) // 2) - len(subtitle) % 2)
+        start_x_keystr = int(
+            (width // 2) - (len(keystr) // 2) - len(keystr) % 2)
         start_y = int((height // 2) - 2)
 
         # Turning on attributes for title

--- a/scripts/ros_docker_controller/docker_controller.py
+++ b/scripts/ros_docker_controller/docker_controller.py
@@ -142,8 +142,10 @@ class DockerController(object):
                 self.container.stop()
                 return
             elif select == 2:
-                self.brand_new_docker_image()
+                self.container.commit(repository='mil_image', tag='latest')
             elif select == 3:
+                self.brand_new_docker_image()
+            elif select == 4:
                 return
 
     def draw_images_menu(self):
@@ -152,7 +154,8 @@ class DockerController(object):
         return self.docker_client.images.list()[selection]
 
     def draw_options_menu(self):
-        l = ['Open Terminal', 'Stop', 'Update Image']
+        l = ['Open Terminal -- opens a terminal window attached to container', 'Stop -- stops the container', 'Save Image -- commits container to image',
+             'Build Image -- runs docker build']
         selection = SelectionMenu.get_selection(l)
         return selection
 

--- a/scripts/ros_docker_controller/docker_controller.py
+++ b/scripts/ros_docker_controller/docker_controller.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+
+import sys,os
+import docker
+import curses
+from cursesmenu import *
+from cursesmenu.items import *
+import distutils.spawn
+import subprocess
+
+class DockerController(object):
+
+    def __init__(self, stdscr):
+        self.stdscr = stdscr
+        self.docker_client = docker.from_env()
+        self.container = None
+        if "RustyROS" in [x.name for x in self.docker_client.containers.list()]:
+            self.container = self.docker_client.containers.get('RustyROS')
+        else:
+            try:
+                self.container = self.docker_client.containers.get('RustyROS')
+                self.container.start()
+            except Exception:
+                self.container = None
+        if not self.docker_client.containers.list():
+            self.brand_new_docker_image()
+
+        self.status = ""
+        self.terminal = None
+        self.find_avaliable_terminal()
+        if(self.terminal is None):
+            assert(False)
+        self.draw()
+
+    def find_avaliable_terminal(self):
+        terminals = ["gnome-terminal", "xterm", "konsole"]
+        for t in terminals:
+            x = distutils.spawn.find_executable(t)
+            if not x is None:
+                self.terminal = t
+
+    def brand_new_docker_image(self):
+        self.stdscr.clear()
+        height, width = self.stdscr.getmaxyx()
+        text = "Building image..."[:width-1]
+        text1 = "To view build process:"[:width-1]
+        text2 = "docker ps"[:width-1]
+        text3 = "docker attach NAME"[:width-1]
+        x = int((width // 2) - (len(text) // 2) - len(text) % 2)
+        y = int((height // 2) - 2)
+        self.stdscr.addstr(y, x, text)
+        self.stdscr.addstr(y+1, x, text1)
+        self.stdscr.addstr(y+2, x, text2)
+        self.stdscr.addstr(y+3, x, text3)
+        self.stdscr.refresh()
+        # Assume dockerfile is in the same relative directory
+        self.docker_client.images.build(path='./', tag='mil_image:latest')
+
+    def open_ros_container(self, img):
+        if not self.container is None:
+            return
+        # Similar to running docker run -it IMG
+        self.container = self.docker_client.containers.run(img, detach=True, tty=True, stdin_open=True, name="RustyROS")
+        self.status = self.status + "| RUNNING"
+
+    def draw(self):
+        k = 0
+        cursor_x = 0
+        cursor_y = 0
+
+        # Clear and refresh the screen for a blank canvas
+        self.stdscr.clear()
+        self.stdscr.refresh()
+
+        # Start colors in curses
+        curses.start_color()
+        curses.init_pair(1, curses.COLOR_CYAN, curses.COLOR_BLACK)
+        curses.init_pair(2, curses.COLOR_RED, curses.COLOR_BLACK)
+        curses.init_pair(3, curses.COLOR_BLACK, curses.COLOR_WHITE)
+
+        # Loop where k is the last character pressed
+        while (k == 0):
+            self.draw_start_menu(k)
+            self.draw_quit_bar()
+
+            # Refresh the screen
+            self.stdscr.refresh()
+
+            # Wait for next input
+            k = self.stdscr.getch()
+            if k == ord('q'):
+                return
+        if k == ord('b'):
+            self.brand_new_docker_image()
+        self.stdscr.clear()
+
+        if self.container is None:
+            selected_image = self.draw_images_menu()
+            self.open_ros_container(selected_image)
+
+        self.stdscr.clear()
+        while (True):
+            self.stdscr.clear()
+            select = self.draw_options_menu()
+            if select == 0:
+                subprocess.Popen([self.terminal, '-e', 'docker exec -it RustyROS bash'])
+            elif select == 1:
+                self.container.stop()
+                return
+            elif select == 2:
+                self.brand_new_docker_image()
+            elif select == 3:
+                return
+
+    def draw_images_menu(self):
+        l = [img.tags for img in self.docker_client.images.list()]
+        selection = SelectionMenu.get_selection(l)
+        return self.docker_client.images.list()[selection]
+
+    def draw_options_menu(self):
+        l = ['Open Terminal', 'Stop', 'Update Image']
+        selection = SelectionMenu.get_selection(l)
+        return selection
+
+
+
+    def draw_quit_bar(self):
+        height, width = self.stdscr.getmaxyx()
+        statusbarstr = "Press 'q' to exit " + self.status
+        # Render status bar
+        self.stdscr.attron(curses.color_pair(3))
+        self.stdscr.addstr(height-1, 0, statusbarstr)
+        self.stdscr.addstr(height-1, len(statusbarstr), " " * (width - len(statusbarstr) - 1))
+        self.stdscr.attroff(curses.color_pair(3))
+
+    def draw_start_menu(self, k):
+        # Initialization
+        self.stdscr.clear()
+        height, width = self.stdscr.getmaxyx()
+
+        # Declaration of strings
+        title = "ROS Docker Controller"[:width-1]
+        subtitle = "Daniel Volya (RustyBamboo)"[:width-1]
+        keystr = "Press any key to continue or b to build fresh MIL image"
+
+        # Centering calculations
+        start_x_title = int((width // 2) - (len(title) // 2) - len(title) % 2)
+        start_x_subtitle = int((width // 2) - (len(subtitle) // 2) - len(subtitle) % 2)
+        start_x_keystr = int((width // 2) - (len(keystr) // 2) - len(keystr) % 2)
+        start_y = int((height // 2) - 2)
+
+        # Turning on attributes for title
+        self.stdscr.attron(curses.color_pair(2))
+        self.stdscr.attron(curses.A_BOLD)
+
+        # Rendering title
+        self.stdscr.addstr(start_y, start_x_title, title)
+
+        # Turning off attributes for title
+        self.stdscr.attroff(curses.color_pair(2))
+        self.stdscr.attroff(curses.A_BOLD)
+
+        # Print rest of text
+        self.stdscr.addstr(start_y + 1, start_x_subtitle, subtitle)
+        self.stdscr.addstr(start_y + 3, (width // 2) - 2, '-' * 4)
+        self.stdscr.addstr(start_y + 5, start_x_keystr, keystr)
+
+
+if __name__ == "__main__":
+    curses.wrapper(DockerController)


### PR DESCRIPTION
If you can run Docker with a base linux system, then you can run ROS easily! 
Kinda WIP

Dockerfile:
- Install a base ubuntu system
- Creates a mil account
- wget install script, which is to be run by user once starting a container

Python Script (ros_docker_controller)
- Detects no images and automatically builds ROS Image
- ncurses interface to start a new container from ROS Image
- check if existing (even stopped) ROS container is avaliable and loads it
- ncurses interface to open a terminal instance or quit

![building](https://user-images.githubusercontent.com/20325227/39774701-9d38abdc-52c9-11e8-9f40-6402a831c190.png)

![image_selection](https://user-images.githubusercontent.com/20325227/39774714-abac0376-52c9-11e8-8dd0-2a0d7207d730.png)

![manage_container](https://user-images.githubusercontent.com/20325227/39774725-b5e4f618-52c9-11e8-9436-239f4a1c9dda.png)

