### PR TITLE
SIMULATION: add gazebo plugin to publish heading between two models

### DIFF
--- a/simulation/mil_gazebo/CMakeLists.txt
+++ b/simulation/mil_gazebo/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(mil_gazebo)
+add_compile_options(-std=c++11)
+
+find_package(catkin REQUIRED COMPONENTS
+  gazebo_dev
+  gazebo_ros
+  mil_msgs
+)
+
+catkin_package(INCLUDE_DIRS include)
+
+include_directories(
+    ${catkin_INCLUDE_DIRS}
+    ${GAZEBO_INCLUDE_DIRS}
+    include
+)
+
+
+add_library(
+    mil_model_heading
+        src/mil_model_heading.cpp
+)
+target_link_libraries(mil_model_heading
+  ${catkin_LIBRARIES}
+  ${GAZEBO_LIBRARIES}
+)
+add_dependencies(mil_model_heading ${catkin_EXPORTED_TARGETS})

--- a/simulation/mil_gazebo/include/mil_gazebo/mil_model_heading.hpp
+++ b/simulation/mil_gazebo/include/mil_gazebo/mil_model_heading.hpp
@@ -1,0 +1,36 @@
+#include <geometry_msgs/Vector3Stamped.h>
+#include <ros/ros.h>
+#include "gazebo/common/common.hh"
+#include "gazebo/gazebo.hh"
+#include "gazebo/physics/physics.hh"
+
+namespace mil_gazebo
+{
+/// Gazebo plugin to publish a heading from one object to another
+class MILModelHeading : public gazebo::ModelPlugin
+{
+public:
+  /// Load plugin
+  void Load(gazebo::physics::ModelPtr _parent, sdf::ElementPtr _sdf);
+  ///
+  void TimerCb(const ros::TimerEvent&);
+  /// Convert a gazebo math vector to a geometry msg
+  static void GazeboVectorToRosMsg(gazebo::math::Vector3 const& in, geometry_msgs::Vector3& out);
+
+private:
+  /// Node handle used for ros interactions
+  ros::NodeHandle nh_;
+  /// Publish to publish vector
+  ros::Publisher vector_pub_;
+  /// Frame of point to publish from
+  std::string frame_;
+  /// Offset from model to where origin is
+  gazebo::math::Pose offset_;
+  /// Pointer to the gazebo world were these models are
+  gazebo::physics::ModelPtr origin_;
+  /// Pointer to model to get heading to
+  gazebo::physics::ModelPtr model_;
+  /// Timer to update ogrid, markers
+  ros::Timer timer_;
+};
+}

--- a/simulation/mil_gazebo/package.xml
+++ b/simulation/mil_gazebo/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>mil_gazebo</name>
+  <version>0.0.0</version>
+  <description>Shared MIL tools for use in the gazebo simulator</description>
+  <maintainer email="kallen@todo.todo">kallen</maintainer>
+  <license>TODO</license>
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>gazebo_dev</build_depend>
+  <build_depend>gazebo_ros</build_depend>
+  <build_depend>mil_msgs</build_depend>
+  <build_depend>point_cloud_object_detection_and_recognition</build_depend>
+  <build_export_depend>gazebo_dev</build_export_depend>
+  <build_export_depend>gazebo_ros</build_export_depend>
+  <build_export_depend>mil_msgs</build_export_depend>
+  <exec_depend>gazebo_dev</exec_depend>
+  <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>mil_msgs</exec_depend>
+  <exec_depend>point_cloud_object_detection_and_recognition</exec_depend>
+</package>

--- a/simulation/mil_gazebo/src/mil_model_heading.cpp
+++ b/simulation/mil_gazebo/src/mil_model_heading.cpp
@@ -1,0 +1,65 @@
+#include <mil_msgs/PerceptionObject.h>
+#include <mil_gazebo/mil_model_heading.hpp>
+
+namespace mil_gazebo
+{
+void MILModelHeading::Load(gazebo::physics::ModelPtr _model, sdf::ElementPtr _sdf)
+{
+  origin_ = _model;
+  std::string topic = "heading";
+  if (_sdf->HasElement("topic"))
+    topic = _sdf->GetElement("topic")->Get<std::string>();
+
+  frame_ = "base_link";
+  if (_sdf->HasElement("frame"))
+    frame_ = _sdf->GetElement("frame")->Get<std::string>();
+
+  offset_ = gazebo::math::Pose();
+  if (_sdf->HasElement("offset"))
+    offset_ = _sdf->GetElement("offset")->Get<gazebo::math::Pose>();
+
+  if (!_sdf->HasElement("model"))
+  {
+    ROS_ERROR_NAMED("MILModelHeading", "missing required attribute <model>");
+    return;
+  }
+
+  std::string model_name = _sdf->GetElement("model")->Get<std::string>();
+  model_ = origin_->GetWorld()->GetModel(model_name);
+  if (!model_)
+  {
+    ROS_ERROR_NAMED("MILModelHeading", "model [%s] does not exist", model_name.c_str());
+    return;
+  }
+
+  double rate = 1.0;
+  if (_sdf->HasElement("rate"))
+    rate = _sdf->GetElement("rate")->Get<double>();
+
+  nh_ = ros::NodeHandle("mil_model_heading");
+  vector_pub_ = nh_.advertise<geometry_msgs::Vector3Stamped>(topic, 1);
+  timer_ = nh_.createTimer(ros::Duration(rate), std::bind(&MILModelHeading::TimerCb, this, std::placeholders::_1));
+}
+
+void MILModelHeading::TimerCb(const ros::TimerEvent&)
+{
+  auto origin_pose = (origin_->GetWorldPose() + offset_).pos;
+  auto model_pose = model_->GetWorldPose().pos;
+  auto difference = model_pose - origin_pose;
+  difference = difference.Normalize();
+  geometry_msgs::Vector3Stamped vec;
+  GazeboVectorToRosMsg(difference, vec.vector);
+  vec.header.frame_id = frame_;
+  vec.header.stamp = ros::Time::now();
+  vector_pub_.publish(vec);
+}
+
+void MILModelHeading::GazeboVectorToRosMsg(gazebo::math::Vector3 const& in, geometry_msgs::Vector3& out)
+{
+  out.x = in.x;
+  out.y = in.y;
+  out.z = in.z;
+}
+
+GZ_REGISTER_MODEL_PLUGIN(MILModelHeading)
+}


### PR DESCRIPTION
Add gazebo plugin to publish a vector between two models. For example, this can be used to simulate the processing of the RobotX pinger, publishing the heading from the hydrophones and the robot